### PR TITLE
When trying to place a Hopium bet, the user is unable to bet their entire money amount.

### DIFF
--- a/website/src/routes/hopium/[id]/+page.svelte
+++ b/website/src/routes/hopium/[id]/+page.svelte
@@ -415,7 +415,7 @@
 								size="lg"
 								disabled={!customBetAmount ||
 									Number(customBetAmount) <= 0 ||
-									Number(customBetAmount) > userBalance ||
+									Number(customBetAmount) >= userBalance ||
 									placingBet ||
 									question.aiResolution !== null}
 								onclick={placeBet}


### PR DESCRIPTION
Fix not being able to bet exact account balance.

![Image](https://github.com/user-attachments/assets/c08da10b-4d43-45a0-93d0-8575193101f3)

![Image](https://github.com/user-attachments/assets/cb3deac6-1055-4c23-858d-5f21fcfbd1b0)