### PR TITLE
Add GitHub Actions for CI Checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,30 @@
+name: Run npm check
+
+on:
+  push:
+    paths:
+      - 'website/**'
+  pull_request:
+    paths:
+      - 'website/**'
+
+jobs:
+  run-check:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: website
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run check
+        run: npm run check

--- a/.github/workflows/websocket.yml
+++ b/.github/workflows/websocket.yml
@@ -1,0 +1,30 @@
+name: Run Bun check
+
+on:
+  push:
+    paths:
+      - 'website/websocket/**'
+  pull_request:
+    paths:
+      - 'website/websocket/**'
+
+jobs:
+  run-bun-check:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: website/websocket
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run type check
+        run: bunx tsc --noEmit

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-.github
 review.js

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && eslint --ext .ts,.svelte src",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
 		"lint": "prettier --check .",


### PR DESCRIPTION
This PR adds two GitHub Actions workflows:

- **check.yml**: Runs `npm run check` on `website/**` changes  
  (`svelte-kit sync`, `svelte-check`, `eslint`)

- **websocket.yml**: Runs `bunx tsc --noEmit` on `website/websocket/**` changes

Also updated the `check` script in `package.json` for stricter linting:
```json
"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && eslint --ext .ts,.svelte src"
```

They are both really simple, just checking out the Repo,then their environment (bun / npm) and run their respective linting checks afterwards
so uh now this checks, for each PR & commit, if the code actually works and uh yeah 👍 

Tested [here ](https://github.com/MD1125/rugplay/actions/runs/15827989543) (Failed due to some svelte errors)

![If you are reading this, you are Gay](https://github.com/user-attachments/assets/797bd7db-fedb-4b14-9a43-eda49549454b)
