### PR TITLE
Fix holding value calculation

### DIFF
--- a/website/src/routes/api/portfolio/summary/+server.ts
+++ b/website/src/routes/api/portfolio/summary/+server.ts
@@ -21,7 +21,8 @@ export async function GET({ request }) {
 
         db.select({
             quantity: userPortfolio.quantity,
-            currentPrice: coin.currentPrice
+            poolCoinAmount: coin.poolCoinAmount,
+            poolBaseCurrencyAmount: coin.poolBaseCurrencyAmount
         })
             .from(userPortfolio)
             .innerJoin(coin, eq(userPortfolio.coinId, coin.id))
@@ -36,8 +37,16 @@ export async function GET({ request }) {
 
     for (const holding of holdings) {
         const quantity = Number(holding.quantity);
-        const price = Number(holding.currentPrice);
-        totalCoinValue += quantity * price;
+        const poolCoinAmount = Number(holding.poolCoinAmount);
+        const poolBaseCurrencyAmount = Number(holding.poolBaseCurrencyAmount);
+
+        // AMM SELL
+        const k = poolCoinAmount * poolBaseCurrencyAmount;
+        const newPoolCoin = poolCoinAmount + quantity;
+        const newPoolBaseCurrency = k / newPoolCoin;
+        const baseCurrencyReceived = poolBaseCurrencyAmount - newPoolBaseCurrency;
+
+        totalCoinValue += baseCurrencyReceived;
     }
 
     const baseCurrencyBalance = Number(userData[0].baseCurrencyBalance);


### PR DESCRIPTION
Missing: prestige sale, coin transfers and rug pull notification minimum

#90 

This calculates the value of a holding through AMM sale instead of `quantity * price`

Currently waiting on #102 and on the question if coin transfers should calculate the value the same way.