### PR TITLE
Added YouTube video link to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img style="width: 128px; height: 128px" src="website/static/favicon.svg" /><h1 style="font-size: 48px"><a href="https://rugplay.com">Rugplay.com</a> - the fake crypto simulator.</h1>
 
-[Privacy Policy](https://rugplay.com/legal/privacy) | [Terms of Service](https://rugplay.com/legal/terms) | [License](LICENSE) | [YouTube video](https://rugplay.com)
+[Privacy Policy](https://rugplay.com/legal/privacy) | [Terms of Service](https://rugplay.com/legal/terms) | [License](LICENSE) | [YouTube video](https://www.youtube.com/watch?v=nRUkvPMphRc)
 
 ## About
 


### PR DESCRIPTION
Title is self-explanatory. The video link was missing in the README and it was still the rugplay.com placeholder. Replaced it with https://www.youtube.com/watch?v=nRUkvPMphRc