### PR TITLE
fix/feat: exact symbol match search on market when search starts with *

### DIFF
--- a/website/src/routes/api/market/+server.ts
+++ b/website/src/routes/api/market/+server.ts
@@ -59,12 +59,16 @@ export async function GET({ url }) {
         const conditions = [eq(coin.isListed, true)];
 
         if (searchQuery) {
-            conditions.push(
-                or(
-                    ilike(coin.name, `%${searchQuery}%`),
-                    ilike(coin.symbol, `%${searchQuery}%`)
-                )!
-            );
+            if(searchQuery.startsWith('*')) {
+                conditions.push(eq(coin.symbol, searchQuery.slice(1)));
+            } else {
+                conditions.push(
+                    or(
+                        ilike(coin.name, `%${searchQuery}%`),
+                        ilike(coin.symbol, `%${searchQuery}%`)
+                    )!
+                );
+            }
         }
 
         switch (priceFilter) {


### PR DESCRIPTION
Simply checks if the search starts with a * and if it does it only returns coins that have a symbol that exactly matches the search.

With so many coins in the market, it's especially harder to find coins with short names like *GB