### PR TITLE
fix: coin symbol preview on coin creation page

### DIFF
--- a/website/src/routes/coin/create/+page.svelte
+++ b/website/src/routes/coin/create/+page.svelte
@@ -231,7 +231,7 @@
 									<p class="text-destructive text-xs">{symbolError}</p>
 								{:else}
 									<p class="text-muted-foreground text-sm">
-										Short identifier for your coin (e.g., BTC for Bitcoin). Will be displayed as *{symbol ||
+										Short identifier for your coin (e.g., BTC for Bitcoin). Will be displayed as *{symbol.toUpperCase() ||
 											'SYMBOL'}
 									</p>
 								{/if}


### PR DESCRIPTION
Made the coin symbol preview on the create coin page uppercase.