### PR TITLE
Fix date formatting to include year if not the same as now

### DIFF
--- a/website/src/lib/utils.ts
+++ b/website/src/lib/utils.ts
@@ -108,7 +108,9 @@ export function formatDate(timestamp: string): string {
         month: 'short',
         day: 'numeric',
         hour: '2-digit',
-        minute: '2-digit'
+        minute: '2-digit',
+		// If different years
+		year: (date.getFullYear() !== new Date().getFullYear()) ? 'numeric' : undefined
     });
 }
 


### PR DESCRIPTION
Since RugPlay are older than a year now, it may collide dates from before july that are from 2025 instead of 2026 ;)