### PR TITLE
Crash gambling game

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1063,7 +1063,6 @@
 			"version": "1.4.18",
 			"resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.18.tgz",
 			"integrity": "sha512-q+awYgC7nkLEBdx2sW0iJjkzgSHlIxGnOpsN1r/O1+a4m7osJNHtfK2mKJSL1I+GfNyIlxJF8WvD/NLuYMpmcg==",
-			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"zod": "^4.3.5"
@@ -1093,14 +1092,12 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
 			"integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@better-fetch/fetch": {
 			"version": "1.1.21",
 			"resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-			"integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
-			"peer": true
+			"integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
 		},
 		"node_modules/@date-fns/tz": {
 			"version": "1.4.1",
@@ -1144,7 +1141,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1161,7 +1157,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1178,7 +1173,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1195,7 +1189,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1212,7 +1205,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1229,7 +1221,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1246,7 +1237,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1263,7 +1253,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1280,7 +1269,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1297,7 +1285,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1314,7 +1301,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1331,7 +1317,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1348,7 +1333,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1365,7 +1349,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1382,7 +1365,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1399,7 +1381,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1416,7 +1397,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1433,7 +1413,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1450,7 +1429,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1467,7 +1445,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1484,7 +1461,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1501,7 +1477,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1568,7 +1543,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1585,7 +1559,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1602,7 +1575,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1619,7 +1591,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1636,7 +1607,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1653,7 +1623,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1670,7 +1639,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1687,7 +1655,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1704,7 +1671,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1721,7 +1687,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1738,7 +1703,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1755,7 +1719,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1772,7 +1735,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1789,7 +1751,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1806,7 +1767,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1823,7 +1783,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1840,7 +1799,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1857,7 +1815,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1874,7 +1831,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1891,7 +1847,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1908,7 +1863,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1925,7 +1879,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1942,7 +1895,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1959,7 +1911,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1976,7 +1927,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1993,7 +1943,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2528,7 +2477,6 @@
 			"integrity": "sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@swc/helpers": "^0.5.0"
 			}
@@ -3980,7 +3928,6 @@
 			"resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
 			"integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cluster-key-slot": "1.1.2"
 			},
@@ -5307,7 +5254,6 @@
 			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.53.0.tgz",
 			"integrity": "sha512-Brh/9h8QEg7rWIj+Nnz/2sC49NUeS8g3Qd9H5dTO3EbWG8vCEUl06jE+r5jQVDMHdr1swmCkwZkONFsWelGTpQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -5349,7 +5295,6 @@
 			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-4.0.4.tgz",
 			"integrity": "sha512-0ba1RQ/PHen5FGpdSrW7Y3fAMQjrXantECALeOiOdBdzR5+5vPP6HVZRLmZaQL+W8m++o+haIAKq5qT+MiZ7VA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^3.0.0-next.0||^3.0.0",
 				"debug": "^4.3.7",
@@ -5409,7 +5354,6 @@
 			"resolved": "https://registry.npmjs.org/@svgdotjs/svg.js/-/svg.js-3.2.5.tgz",
 			"integrity": "sha512-/VNHWYhNu+BS7ktbYoVGrCmsXDh+chFMaONMwGNdIBcFHrWqk2jY8fNyr3DLdtQUIalvkPfM554ZSFa3dm3nxQ==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Fuzzyma"
@@ -5433,7 +5377,6 @@
 			"resolved": "https://registry.npmjs.org/@svgdotjs/svg.select.js/-/svg.select.js-4.0.3.tgz",
 			"integrity": "sha512-qkMgso1sd2hXKd1FZ1weO7ANq12sNmQJeGDjs46QwDVsxSRcHmvWKL2NDF7Yimpwf3sl5esOLkPqtV2bQ3v/Jg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 14.18"
 			},
@@ -5931,7 +5874,6 @@
 			"integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -6015,7 +5957,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -6222,7 +6163,6 @@
 			"resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.8.tgz",
 			"integrity": "sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@better-auth/utils": "^0.3.0",
 				"@better-fetch/fetch": "^1.1.4",
@@ -6319,7 +6259,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -6797,7 +6736,6 @@
 			"integrity": "sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@drizzle-team/brocli": "^0.10.2",
 				"@esbuild-kit/esm-loader": "^2.5.5",
@@ -6813,7 +6751,6 @@
 			"resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.1.tgz",
 			"integrity": "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"peerDependencies": {
 				"@aws-sdk/client-rds-data": ">=3",
 				"@cloudflare/workers-types": ">=4",
@@ -7037,7 +6974,6 @@
 			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -7575,7 +7511,6 @@
 			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
 			"integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
 			}
@@ -7584,7 +7519,8 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
@@ -7600,7 +7536,6 @@
 			"resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.11.tgz",
 			"integrity": "sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=20.0.0"
 			}
@@ -7859,7 +7794,6 @@
 			"resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.1.0.tgz",
 			"integrity": "sha512-jEAYR4ODYeyNZcWUigsoLTl52rbPmgXnvd5FLIv/ZoA/2sSDw63YKnef8n4yhzum7W926yHeFwlm7ididKb7YQ==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"fancy-canvas": "2.1.0"
 			}
@@ -7875,6 +7809,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			},
@@ -8109,7 +8044,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "^20.0.0 || >=22.0.0"
 			}
@@ -8141,6 +8075,7 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8274,7 +8209,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -8309,7 +8243,6 @@
 			"resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.8.tgz",
 			"integrity": "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==",
 			"license": "Unlicense",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -8324,7 +8257,6 @@
 			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -8341,7 +8273,6 @@
 			"integrity": "sha512-2lLO/7EupnjO/95t+XZesXs8Bf3nYLIDfCo270h5QWbj/vjLqmrQ1LiRk9LPggxSDsnVYfehamZNf+rgQYApZg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"prettier": "^3.0.0",
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
@@ -8439,6 +8370,7 @@
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -8449,7 +8381,8 @@
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
@@ -8575,7 +8508,6 @@
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
 			"integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/use-sync-external-store": "^0.0.6",
 				"use-sync-external-store": "^1.4.0"
@@ -8736,8 +8668,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/redux-thunk": {
 			"version": "3.1.0",
@@ -8796,7 +8727,6 @@
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.58.0.tgz",
 			"integrity": "sha512-wbT0mBmWbIvvq8NeEYWWvevvxnOyhKChir47S66WCxw1SXqhw7ssIYejnQEVt7XYQpsj2y8F9PM+Cr3SNEa0gw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -8906,7 +8836,8 @@
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
 			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/semver": {
 			"version": "7.7.4",
@@ -9195,7 +9126,6 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.1.tgz",
 			"integrity": "sha512-WzxFHZhhD23Qzu7JCYdvm1rxvRSzdt9HtHO8TScMBX51bLRFTcJmATVqjqXG+6Ln6hrViGCo9DzwOhAasxwC/w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -9498,8 +9428,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.0.tgz",
 			"integrity": "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -9574,7 +9503,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -9730,7 +9658,6 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
 			"integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",

--- a/website/src/hooks.server.ts
+++ b/website/src/hooks.server.ts
@@ -13,6 +13,11 @@ import { towerCleanupInactiveGames } from '$lib/server/games/tower';
 import { crashAdvanceRounds } from '$lib/server/games/crash';
 import { checkRateLimit } from '$lib/server/ratelimit';
 
+// NOTE: rules are checked in order and the first match wins (see the `break`
+// below), so more specific rules must come before the generic '/api/arcade/'
+// catch-all. It used to sit first, which meant it swallowed every arcade
+// request — including '/bet' endpoints — and the stricter per-bet limit
+// below could never actually apply.
 const RATE_RULES: Array<{
     match: (path: string, method: string) => boolean;
     key: string;
@@ -20,10 +25,10 @@ const RATE_RULES: Array<{
     windowSecs: number;
 }> = [
     {
-        match: (p) => p.startsWith('/api/arcade/'),
-        key: 'arcade',
+        match: (p) => p.endsWith('/bet'),
+        key: 'bet',
         limit: 10,
-        windowSecs: 5
+        windowSecs: 60
     },
     {
         match: (p) => p.endsWith('/trade'),
@@ -38,10 +43,10 @@ const RATE_RULES: Array<{
         windowSecs: 60
     },
     {
-        match: (p) => p.endsWith('/bet'),
-        key: 'bet',
+        match: (p) => p.startsWith('/api/arcade/'),
+        key: 'arcade',
         limit: 10,
-        windowSecs: 60
+        windowSecs: 5
     }
 ];
 
@@ -96,9 +101,19 @@ async function initializeScheduler() {
 				towerCleanupInactiveGames().catch(console.error);
 			}, 60 * 1000);
 
-			// Crash game round advancement (every 500ms for smooth transitions)
+			// Crash game round advancement (every 500ms for smooth transitions).
+			// Guarded against overlap: settlement inside crashAdvanceRounds can take
+			// longer than 500ms when a round has many bets, and letting ticks stack up
+			// risks concurrent runs racing on the same round state in Redis.
+			let crashTickRunning = false;
 			const crashInterval = setInterval(() => {
-				crashAdvanceRounds().catch(console.error);
+				if (crashTickRunning) return;
+				crashTickRunning = true;
+				crashAdvanceRounds()
+					.catch(console.error)
+					.finally(() => {
+						crashTickRunning = false;
+					});
 			}, 500);
 
             // Cleanup on process exit

--- a/website/src/hooks.server.ts
+++ b/website/src/hooks.server.ts
@@ -10,6 +10,7 @@ import { user } from '$lib/server/db/schema';
 import { eq } from 'drizzle-orm';
 import { minesCleanupInactiveGames, minesAutoCashout } from '$lib/server/games/mines';
 import { towerCleanupInactiveGames } from '$lib/server/games/tower';
+import { crashAdvanceRounds } from '$lib/server/games/crash';
 import { checkRateLimit } from '$lib/server/ratelimit';
 
 const RATE_RULES: Array<{
@@ -89,22 +90,28 @@ async function initializeScheduler() {
                 cleanupExpiredSessions().catch(console.error);
             }, 5 * 60 * 1000);
 
-            const minesCleanupInterval = setInterval(() => {
-                minesCleanupInactiveGames().catch(console.error);
-                minesAutoCashout().catch(console.error);
-                towerCleanupInactiveGames().catch(console.error);
-            }, 60 * 1000);
+			const minesCleanupInterval = setInterval(() => {
+				minesCleanupInactiveGames().catch(console.error);
+				minesAutoCashout().catch(console.error);
+				towerCleanupInactiveGames().catch(console.error);
+			}, 60 * 1000);
+
+			// Crash game round advancement (every 500ms for smooth transitions)
+			const crashInterval = setInterval(() => {
+				crashAdvanceRounds().catch(console.error);
+			}, 500);
 
             // Cleanup on process exit
-            const cleanup = async () => {
-                clearInterval(renewInterval);
-                clearInterval(schedulerInterval);
-                clearInterval(minesCleanupInterval);
-                const currentValue = await redis.get(lockKey);
-                if (currentValue === lockValue) {
-                    await redis.del(lockKey);
-                }
-            };
+			const cleanup = async () => {
+				clearInterval(renewInterval);
+				clearInterval(schedulerInterval);
+				clearInterval(minesCleanupInterval);
+				clearInterval(crashInterval);
+				const currentValue = await redis.get(lockKey);
+				if (currentValue === lockValue) {
+					await redis.del(lockKey);
+				}
+			};
 
             process.on('SIGTERM', cleanup);
             process.on('SIGINT', cleanup);

--- a/website/src/lib/components/self/games/Crash.svelte
+++ b/website/src/lib/components/self/games/Crash.svelte
@@ -29,6 +29,12 @@
 	const MIN_BET_AMOUNT = 0.01;
 	const WAITING_MS = 8000;
 	const PAUSE_MS = 5000;
+	const MAX_CRASH_POINT = 10_000;
+	// Fixed chart scale — the Y-axis uses a constant log range so the curve grows
+	// upward naturally instead of re-normalizing every frame (which made the graph
+	// shrink/diminish as the multiplier passed ~1.5x).
+	const CHART_MAX_MULTIPLIER = 100;
+	const CHART_MAX_POINTS = 400;
 
 	let {
 		balance = $bindable(),
@@ -152,7 +158,7 @@
 	}
 
 	function resetChart() {
-		chartPoints = [];
+		chartPoints = [{ x: 0, y: 1 }];
 		if (ctx && canvas) {
 			ctx.clearRect(0, 0, canvas.clientWidth, canvas.clientHeight);
 		}
@@ -192,16 +198,20 @@
 
 		if (chartPoints.length < 2) return;
 
-		let maxY = 1.01;
-		let maxX = 1;
-		for (const p of chartPoints) {
-			if (p.y > maxY) maxY = p.y;
-			if (p.x > maxX) maxX = p.x;
-		}
-
+		// Fixed scales — the curve grows naturally without re-normalizing.
+		// Y-axis: constant log range from 1x to CHART_MAX_MULTIPLIER, so the curve
+		// always starts at the bottom and climbs upward as the multiplier grows.
+		// X-axis: scrolling window over the last CHART_MAX_POINTS points, so the
+		// curve moves rightward and scrolls left instead of compressing.
+		const maxLogY = Math.log(CHART_MAX_MULTIPLIER);
+		const logRange = maxLogY; // log(1) = 0
+		const firstX = chartPoints[0].x;
+		const lastX = chartPoints[chartPoints.length - 1].x;
+		const xRange = Math.max(1, lastX - firstX);
 		const toXY = (p: { x: number; y: number }) => {
-			const x = (p.x / maxX) * w;
-			const y = h - (p.y / maxY) * (h - 24) - 12;
+			const x = ((p.x - firstX) / xRange) * w;
+			const logY = Math.log(Math.max(p.y, 1));
+			const y = h - (logY / logRange) * (h - 24) - 12;
 			return [x, y] as const;
 		};
 
@@ -259,7 +269,7 @@
 	function addChartPoint(mult: number) {
 		const x = chartPoints.length > 0 ? chartPoints[chartPoints.length - 1].x + 1 : 0;
 		chartPoints.push({ x, y: mult });
-		if (chartPoints.length > 400) chartPoints.shift();
+		if (chartPoints.length > CHART_MAX_POINTS) chartPoints.shift();
 		drawChart();
 	}
 
@@ -392,6 +402,13 @@
 			}
 			hasBet = false;
 			cashedOut = false;
+
+			// Prepend the newly crashed round to the recent-crashes history without
+			// waiting for a page refresh / state refetch. Guard against duplicates
+			// in case of reconnect replays or duplicate broadcasts.
+			if (msg.historyEntry && !history.some((h) => h.roundId === msg.historyEntry.roundId)) {
+				history = [msg.historyEntry, ...history].slice(0, 50);
+			}
 		}
 	}
 
@@ -417,6 +434,7 @@
 					if (chartAnimationId) cancelAnimationFrame(chartAnimationId);
 					chartAnimationId = requestAnimationFrame(animateChart);
 				} else if (data.round.status === 'crashed') {
+					resetChart();
 					crashPoint = data.round.crashPoint;
 					addChartPoint(data.round.crashPoint);
 					currentMultiplier = data.round.crashPoint;
@@ -849,7 +867,7 @@
 		text-shadow: 0 0 24px currentColor;
 	}
 
-	.cashout-btn {
+	:global(.cashout-btn) {
 		animation: cashout-pulse 1.4s ease-in-out infinite;
 	}
 

--- a/website/src/lib/components/self/games/Crash.svelte
+++ b/website/src/lib/components/self/games/Crash.svelte
@@ -1,0 +1,901 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Switch } from '$lib/components/ui/switch';
+	import { Badge } from '$lib/components/ui/badge';
+	import * as Tooltip from '$lib/components/ui/tooltip';
+	import {
+		Card,
+		CardContent,
+		CardDescription,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card';
+	import confetti from 'canvas-confetti';
+	import { toast } from 'svelte-sonner';
+	import { formatValue, playSound, showConfetti } from '$lib/utils';
+	import { volumeSettings } from '$lib/stores/volume-settings';
+	import { haptic } from '$lib/stores/haptics';
+	import { onMount, onDestroy } from 'svelte';
+	import { fetchPortfolioSummary } from '$lib/stores/portfolio-data';
+	import { PUBLIC_WEBSOCKET_URL } from '$env/static/public';
+	import { HugeiconsIcon } from '@hugeicons/svelte';
+	import { TradeUpIcon, Target03Icon, Clock01Icon } from '@hugeicons/core-free-icons';
+
+	type RoundStatus = 'waiting' | 'running' | 'crashed';
+
+	// Mirrors server-side constants (server module can't be imported client-side)
+	const MAX_BET_AMOUNT = 100_000;
+	const MIN_BET_AMOUNT = 0.01;
+	const WAITING_MS = 8000;
+	const PAUSE_MS = 5000;
+
+	let {
+		balance = $bindable(),
+		onBalanceUpdate
+	}: {
+		balance: number;
+		onBalanceUpdate?: (newBalance: number) => void;
+	} = $props();
+
+	let bet = $state(10);
+	let betDisplay = $state('10');
+	let playing = $state(false);
+	let hasBet = $state(false);
+	let cashedOut = $state(false);
+	let busy = $state(false);
+	let roundStatus = $state<RoundStatus>('waiting');
+	let currentMultiplier = $state(1);
+	let crashPoint = $state<number | null>(null);
+	let roundId = $state(0);
+	let serverSeedHash = $state('');
+	let serverSeed = $state<string | null>(null);
+	let nonce = $state(0);
+	let waitingStartedAt = $state(0);
+	let startTime = $state(0);
+	let crashedAt = $state(0);
+	let betCount = $state(0);
+	let history = $state<
+		{
+			roundId: number;
+			crashPoint: number;
+			serverSeed: string;
+			serverSeedHash: string;
+			nonce: number;
+			crashedAt: number;
+		}[]
+	>([]);
+	let myBetAmount = $state(0);
+	let myPayout = $state(0);
+	let myMultiplier = $state(0);
+	let lastResult = $state<'won' | 'lost' | null>(null);
+	let lastPayout = $state(0);
+	let shaking = $state(false);
+	let connected = $state(false);
+
+	// Auto cash-out
+	let autoCashoutEnabled = $state(false);
+	let autoCashoutTarget = $state(2);
+	let autoCashoutDisplay = $state('2.00');
+	let autoCashoutTriggered = $state(false);
+
+	// Countdown bars
+	let waitingProgress = $state(0);
+	let waitingRemaining = $state(0);
+	let pauseProgress = $state(0);
+	let pauseRemaining = $state(0);
+
+	// Chart state
+	let canvas: HTMLCanvasElement;
+	let ctx: CanvasRenderingContext2D | null = null;
+	let chartPoints: { x: number; y: number }[] = [];
+	let chartAnimationId: number | null = null;
+	let uiTickInterval: ReturnType<typeof setInterval> | null = null;
+	let resizeObserver: ResizeObserver | null = null;
+
+	// WebSocket
+	let ws: WebSocket | null = null;
+	let wsReconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+	let canBet = $derived(
+		bet > 0 &&
+			bet <= balance &&
+			bet <= MAX_BET_AMOUNT &&
+			roundStatus === 'waiting' &&
+			!hasBet &&
+			!playing
+	);
+
+	let riskColor = $derived(
+		roundStatus === 'crashed'
+			? '#ef4444'
+			: currentMultiplier >= 5
+				? '#f59e0b'
+				: currentMultiplier >= 2
+					? '#eab308'
+					: '#22c55e'
+	);
+
+	function setBet(amount: number) {
+		const v = Math.min(amount, Math.min(balance, MAX_BET_AMOUNT));
+		if (v >= 0) {
+			bet = v;
+			betDisplay = v.toLocaleString();
+		}
+	}
+
+	function onBetInput(e: Event) {
+		const raw = (e.target as HTMLInputElement).value.replace(/,/g, '');
+		const n = parseFloat(raw) || 0;
+		bet = Math.min(n, Math.min(balance, MAX_BET_AMOUNT));
+		betDisplay = raw;
+	}
+
+	function onAutoCashoutInput(e: Event) {
+		const raw = (e.target as HTMLInputElement).value;
+		const n = parseFloat(raw) || 0;
+		autoCashoutTarget = Math.max(1.01, n);
+		autoCashoutDisplay = raw;
+	}
+
+	// --- Canvas rendering (DPI aware, gradient fill, glowing tip) ---
+	function resizeCanvas() {
+		if (!canvas || !ctx) return;
+		const dpr = window.devicePixelRatio || 1;
+		const rect = canvas.getBoundingClientRect();
+		const w = Math.max(1, Math.floor(rect.width));
+		const h = Math.max(1, Math.floor(rect.height));
+		canvas.width = Math.floor(w * dpr);
+		canvas.height = Math.floor(h * dpr);
+		ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+		drawChart();
+	}
+
+	function resetChart() {
+		chartPoints = [];
+		if (ctx && canvas) {
+			ctx.clearRect(0, 0, canvas.clientWidth, canvas.clientHeight);
+		}
+	}
+
+	function hexToRgb(hex: string): string {
+		const m = hex.replace('#', '');
+		const r = parseInt(m.substring(0, 2), 16);
+		const g = parseInt(m.substring(2, 4), 16);
+		const b = parseInt(m.substring(4, 6), 16);
+		return `${r},${g},${b}`;
+	}
+
+	function drawChart() {
+		if (!ctx || !canvas) return;
+		const w = canvas.clientWidth;
+		const h = canvas.clientHeight;
+		ctx.clearRect(0, 0, w, h);
+
+		// Background grid
+		ctx.strokeStyle = 'rgba(128,128,128,0.12)';
+		ctx.lineWidth = 1;
+		for (let i = 1; i < 5; i++) {
+			const y = (h / 5) * i;
+			ctx.beginPath();
+			ctx.moveTo(0, y);
+			ctx.lineTo(w, y);
+			ctx.stroke();
+		}
+		for (let i = 1; i < 6; i++) {
+			const x = (w / 6) * i;
+			ctx.beginPath();
+			ctx.moveTo(x, 0);
+			ctx.lineTo(x, h);
+			ctx.stroke();
+		}
+
+		if (chartPoints.length < 2) return;
+
+		let maxY = 1.01;
+		let maxX = 1;
+		for (const p of chartPoints) {
+			if (p.y > maxY) maxY = p.y;
+			if (p.x > maxX) maxX = p.x;
+		}
+
+		const toXY = (p: { x: number; y: number }) => {
+			const x = (p.x / maxX) * w;
+			const y = h - (p.y / maxY) * (h - 24) - 12;
+			return [x, y] as const;
+		};
+
+		const strokeColor = roundStatus === 'crashed' ? '#ef4444' : riskColor;
+		const rgb = hexToRgb(strokeColor);
+
+		// Gradient fill under the curve
+		const gradient = ctx.createLinearGradient(0, 0, 0, h);
+		gradient.addColorStop(0, `rgba(${rgb},0.35)`);
+		gradient.addColorStop(1, `rgba(${rgb},0)`);
+
+		ctx.beginPath();
+		const [fx] = toXY(chartPoints[0]);
+		ctx.moveTo(fx, h);
+		for (let i = 0; i < chartPoints.length; i++) {
+			const [x, y] = toXY(chartPoints[i]);
+			ctx.lineTo(x, y);
+		}
+		const [lx] = toXY(chartPoints[chartPoints.length - 1]);
+		ctx.lineTo(lx, h);
+		ctx.closePath();
+		ctx.fillStyle = gradient;
+		ctx.fill();
+
+		// Glowing stroke on top of the curve
+		ctx.save();
+		ctx.shadowColor = strokeColor;
+		ctx.shadowBlur = 12;
+		ctx.strokeStyle = strokeColor;
+		ctx.lineWidth = 3;
+		ctx.lineJoin = 'round';
+		ctx.lineCap = 'round';
+		ctx.beginPath();
+		for (let i = 0; i < chartPoints.length; i++) {
+			const [x, y] = toXY(chartPoints[i]);
+			if (i === 0) ctx.moveTo(x, y);
+			else ctx.lineTo(x, y);
+		}
+		ctx.stroke();
+		ctx.restore();
+
+		// Glowing tip
+		const last = chartPoints[chartPoints.length - 1];
+		const [tx, ty] = toXY(last);
+		ctx.save();
+		ctx.shadowColor = strokeColor;
+		ctx.shadowBlur = 18;
+		ctx.beginPath();
+		ctx.arc(tx, ty, 5, 0, Math.PI * 2);
+		ctx.fillStyle = strokeColor;
+		ctx.fill();
+		ctx.restore();
+	}
+
+	function addChartPoint(mult: number) {
+		const x = chartPoints.length > 0 ? chartPoints[chartPoints.length - 1].x + 1 : 0;
+		chartPoints.push({ x, y: mult });
+		if (chartPoints.length > 400) chartPoints.shift();
+		drawChart();
+	}
+
+	function animateChart() {
+		if (roundStatus !== 'running') return;
+
+		if (startTime > 0) {
+			const elapsed = Date.now() - startTime;
+			const mult = Math.floor(Math.exp(0.1 * (elapsed / 1000)) * 100) / 100;
+			currentMultiplier = mult;
+			addChartPoint(mult);
+		}
+
+		chartAnimationId = requestAnimationFrame(animateChart);
+	}
+
+	function triggerShake() {
+		shaking = true;
+		setTimeout(() => (shaking = false), 400);
+	}
+
+	function crashBurst() {
+		try {
+			confetti({
+				particleCount: 60,
+				spread: 100,
+				startVelocity: 35,
+				colors: ['#ef4444', '#f97316', '#7f1d1d'],
+				origin: { x: 0.5, y: 0.45 },
+				ticks: 60,
+				scalar: 0.9
+			});
+		} catch {}
+	}
+
+	// --- UI countdown ticker (waiting / pause phases) ---
+	function tickCountdowns() {
+		const now = Date.now();
+		if (roundStatus === 'waiting' && waitingStartedAt > 0) {
+			const elapsed = now - waitingStartedAt;
+			waitingProgress = Math.min(100, (elapsed / WAITING_MS) * 100);
+			waitingRemaining = Math.max(0, WAITING_MS - elapsed);
+		}
+		if (roundStatus === 'crashed' && crashedAt > 0) {
+			const elapsed = now - crashedAt;
+			pauseProgress = Math.min(100, (elapsed / PAUSE_MS) * 100);
+			pauseRemaining = Math.max(0, PAUSE_MS - elapsed);
+		}
+	}
+
+	function connectWS() {
+		if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) return;
+		try {
+			ws = new WebSocket(PUBLIC_WEBSOCKET_URL);
+			ws.onopen = () => {
+				connected = true;
+			};
+			ws.onmessage = (event) => {
+				try {
+					const msg = JSON.parse(event.data);
+					if (msg.type === 'crash_round') {
+						handleRoundUpdate(msg);
+					}
+				} catch (e) {
+					console.error('Crash WS parse error:', e);
+				}
+			};
+			ws.onclose = () => {
+				ws = null;
+				connected = false;
+				if (wsReconnectTimer) clearTimeout(wsReconnectTimer);
+				wsReconnectTimer = setTimeout(connectWS, 5000);
+			};
+			ws.onerror = () => {
+				ws?.close();
+			};
+		} catch (e) {
+			console.error('Crash WS connect error:', e);
+		}
+	}
+
+	function handleRoundUpdate(msg: any) {
+		roundId = msg.roundId;
+		roundStatus = msg.status;
+		serverSeedHash = msg.serverSeedHash;
+		nonce = msg.nonce;
+		waitingStartedAt = msg.waitingStartedAt;
+		startTime = msg.startTime;
+		crashedAt = msg.crashedAt;
+		betCount = msg.betCount;
+
+		if (msg.status === 'waiting') {
+			crashPoint = null;
+			serverSeed = null;
+			resetChart();
+			currentMultiplier = 1;
+			autoCashoutTriggered = false;
+			// Reset bet state for new round
+			hasBet = false;
+			cashedOut = false;
+			playing = false;
+			lastResult = null;
+			lastPayout = 0;
+			myBetAmount = 0;
+			myPayout = 0;
+			myMultiplier = 0;
+		} else if (msg.status === 'running') {
+			crashPoint = null;
+			serverSeed = null;
+			resetChart();
+			currentMultiplier = 1;
+			if (chartAnimationId) cancelAnimationFrame(chartAnimationId);
+			chartAnimationId = requestAnimationFrame(animateChart);
+		} else if (msg.status === 'crashed') {
+			crashPoint = msg.crashPoint;
+			serverSeed = msg.serverSeed;
+			if (chartAnimationId) cancelAnimationFrame(chartAnimationId);
+			chartAnimationId = null;
+			addChartPoint(msg.crashPoint);
+			currentMultiplier = msg.crashPoint;
+			playing = false;
+			triggerShake();
+			crashBurst();
+			haptic.trigger('error');
+			// If we had a bet and didn't cash out, we lost
+			if (hasBet && !cashedOut) {
+				lastResult = 'lost';
+				lastPayout = 0;
+				playSound('lose');
+			}
+			hasBet = false;
+			cashedOut = false;
+		}
+	}
+
+	async function loadState() {
+		try {
+			const res = await fetch('/api/arcade/crash/state');
+			if (!res.ok) return;
+			const data = await res.json();
+			if (data.round) {
+				roundId = data.round.roundId;
+				roundStatus = data.round.status;
+				serverSeedHash = data.round.serverSeedHash;
+				serverSeed = data.round.serverSeed;
+				nonce = data.round.nonce;
+				waitingStartedAt = data.round.waitingStartedAt;
+				startTime = data.round.startTime;
+				crashedAt = data.round.crashedAt;
+				betCount = data.round.betCount;
+				currentMultiplier = data.round.currentMultiplier;
+
+				if (data.round.status === 'running') {
+					resetChart();
+					if (chartAnimationId) cancelAnimationFrame(chartAnimationId);
+					chartAnimationId = requestAnimationFrame(animateChart);
+				} else if (data.round.status === 'crashed') {
+					crashPoint = data.round.crashPoint;
+					addChartPoint(data.round.crashPoint);
+					currentMultiplier = data.round.crashPoint;
+				}
+			}
+			if (data.userBet) {
+				hasBet = true;
+				myBetAmount = data.userBet.betAmount;
+				if (data.userBet.cashedOut) {
+					cashedOut = true;
+					myPayout = data.userBet.payout || 0;
+					myMultiplier = data.userBet.cashoutMultiplier || 0;
+				}
+			}
+			if (data.history) {
+				history = data.history;
+			}
+		} catch (e) {
+			console.error('Crash load state error:', e);
+		}
+	}
+
+	async function placeBet() {
+		if (!canBet || busy) return;
+		busy = true;
+		try {
+			const res = await fetch('/api/arcade/crash/bet', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ amount: bet })
+			});
+			if (!res.ok) throw new Error((await res.json()).error || 'Failed');
+			const data = await res.json();
+			balance = data.newBalance;
+			onBalanceUpdate?.(data.newBalance);
+			hasBet = true;
+			myBetAmount = bet;
+			playing = true;
+			autoCashoutTriggered = false;
+			haptic.trigger('light');
+			playSound('flip');
+		} catch (err) {
+			toast.error('Failed to place bet', {
+				description: err instanceof Error ? err.message : 'Unknown error'
+			});
+		} finally {
+			busy = false;
+		}
+	}
+
+	async function cashout() {
+		if (!hasBet || cashedOut || roundStatus !== 'running' || busy) return;
+		busy = true;
+		try {
+			const res = await fetch('/api/arcade/crash/cashout', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' }
+			});
+			if (!res.ok) throw new Error((await res.json()).error || 'Failed');
+			const data = await res.json();
+			balance = data.newBalance;
+			onBalanceUpdate?.(data.newBalance);
+			cashedOut = true;
+			myPayout = data.payout;
+			myMultiplier = data.multiplier;
+			lastResult = 'won';
+			lastPayout = data.payout;
+			playing = false;
+			if (data.payout > myBetAmount) {
+				haptic.trigger('success');
+				showConfetti(confetti);
+				playSound('win');
+			} else {
+				playSound('flip');
+			}
+		} catch (err) {
+			// Round likely crashed right before the request landed
+			toast.error('Failed to cash out', {
+				description: err instanceof Error ? err.message : 'Unknown error'
+			});
+		} finally {
+			busy = false;
+		}
+	}
+
+	// Client-side auto cash-out: fires once the live multiplier reaches the target.
+	$effect(() => {
+		if (
+			autoCashoutEnabled &&
+			hasBet &&
+			!cashedOut &&
+			!autoCashoutTriggered &&
+			roundStatus === 'running' &&
+			currentMultiplier >= autoCashoutTarget &&
+			!busy
+		) {
+			autoCashoutTriggered = true;
+			cashout();
+		}
+	});
+
+	onMount(async () => {
+		if (canvas) {
+			ctx = canvas.getContext('2d');
+			resizeCanvas();
+			resizeObserver = new ResizeObserver(() => resizeCanvas());
+			resizeObserver.observe(canvas);
+		}
+		volumeSettings.load();
+		uiTickInterval = setInterval(tickCountdowns, 100);
+		try {
+			const data = await fetchPortfolioSummary();
+			if (data) {
+				balance = data.baseCurrencyBalance;
+				onBalanceUpdate?.(data.baseCurrencyBalance);
+			}
+		} catch {}
+		await loadState();
+		connectWS();
+	});
+
+	onDestroy(() => {
+		if (chartAnimationId) cancelAnimationFrame(chartAnimationId);
+		if (wsReconnectTimer) clearTimeout(wsReconnectTimer);
+		if (uiTickInterval) clearInterval(uiTickInterval);
+		resizeObserver?.disconnect();
+		ws?.close();
+	});
+</script>
+
+<Card>
+	<CardHeader>
+		<div class="flex items-center justify-between">
+			<div>
+				<CardTitle class="flex items-center gap-2">
+					<HugeiconsIcon icon={TradeUpIcon} class="h-5 w-5" />
+					Crash
+				</CardTitle>
+				<CardDescription>Watch the multiplier climb and cash out before it crashes!</CardDescription>
+			</div>
+			<Badge
+				variant="outline"
+				class="gap-1.5 {roundStatus === 'running'
+					? 'border-green-500/40 text-green-500'
+					: roundStatus === 'crashed'
+						? 'border-red-500/40 text-red-500'
+						: 'border-yellow-500/40 text-yellow-500'}"
+			>
+				<span
+					class="h-1.5 w-1.5 rounded-full {roundStatus === 'running'
+						? 'animate-pulse bg-green-500'
+						: roundStatus === 'crashed'
+							? 'bg-red-500'
+							: 'animate-pulse bg-yellow-500'}"
+				></span>
+				{roundStatus === 'running' ? 'Live' : roundStatus === 'crashed' ? 'Crashed' : 'Betting Open'}
+			</Badge>
+		</div>
+	</CardHeader>
+	<CardContent>
+		<div class="grid grid-cols-1 gap-6 md:grid-cols-3">
+			<!-- Chart -->
+			<div class="md:col-span-2">
+				<div
+					class="crash-chart-wrap relative overflow-hidden rounded-lg border"
+					class:shake={shaking}
+					class:crashed-flash={roundStatus === 'crashed' && shaking}
+				>
+					<canvas bind:this={canvas} class="h-64 w-full md:h-80"></canvas>
+
+					<!-- Overlay: big multiplier readout -->
+					<div class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+						{#if roundStatus === 'waiting'}
+							<div class="text-center">
+								<p class="text-muted-foreground mb-2 text-sm">Next round starting in</p>
+								<p class="text-4xl font-bold tabular-nums">
+									{(waitingRemaining / 1000).toFixed(1)}s
+								</p>
+								<div class="bg-muted mt-3 h-1.5 w-40 overflow-hidden rounded-full">
+									<div
+										class="bg-primary h-full transition-all duration-100"
+										style="width: {waitingProgress}%"
+									></div>
+								</div>
+							</div>
+						{:else if roundStatus === 'running'}
+							<p
+								class="crash-multiplier text-5xl font-extrabold tabular-nums transition-transform duration-150 md:text-6xl"
+								style="color: {riskColor}; transform: scale({1 + Math.min(currentMultiplier / 40, 0.25)});"
+							>
+								{currentMultiplier.toFixed(2)}x
+							</p>
+						{:else if roundStatus === 'crashed'}
+							<div class="text-center">
+								<p class="text-4xl font-extrabold text-red-500 md:text-5xl">
+									Crashed @ {crashPoint?.toFixed(2)}x
+								</p>
+								<p class="text-muted-foreground mt-2 text-xs">
+									Next round in {(pauseRemaining / 1000).toFixed(1)}s
+								</p>
+								<div class="bg-muted mx-auto mt-2 h-1 w-32 overflow-hidden rounded-full">
+									<div
+										class="h-full bg-red-500/70 transition-all duration-100"
+										style="width: {pauseProgress}%"
+									></div>
+								</div>
+							</div>
+						{/if}
+					</div>
+				</div>
+
+				<!-- History -->
+				<div class="mt-4">
+					<p class="text-muted-foreground mb-2 text-sm">Recent crashes</p>
+					<div class="flex flex-wrap gap-2">
+						{#each history.slice(0, 20) as h (h.roundId)}
+							<Tooltip.Root>
+								<Tooltip.Trigger>
+									<span
+										class="history-chip rounded px-2 py-1 font-mono text-xs {h.crashPoint < 1.5
+											? 'bg-red-500/10 text-red-500'
+											: h.crashPoint < 2
+												? 'bg-orange-500/10 text-orange-500'
+												: h.crashPoint < 5
+													? 'bg-yellow-500/10 text-yellow-500'
+													: 'bg-green-500/10 text-green-500'}"
+									>
+										{h.crashPoint.toFixed(2)}x
+									</span>
+								</Tooltip.Trigger>
+								<Tooltip.Content class="max-w-64">
+									<p class="text-xs font-medium">Round #{h.roundId} — {h.crashPoint.toFixed(2)}x</p>
+									<p class="text-muted-foreground mt-1 break-all font-mono text-[10px]">
+										Seed: {h.serverSeed}
+									</p>
+									<p class="text-muted-foreground break-all font-mono text-[10px]">
+										Hash: {h.serverSeedHash.slice(0, 24)}…
+									</p>
+								</Tooltip.Content>
+							</Tooltip.Root>
+						{/each}
+						{#if history.length === 0}
+							<p class="text-muted-foreground text-xs">No rounds played yet</p>
+						{/if}
+					</div>
+				</div>
+			</div>
+
+			<!-- Controls -->
+			<div class="space-y-4">
+				<div class="text-center">
+					<p class="text-muted-foreground text-sm">Balance</p>
+					<p class="text-2xl font-bold">{formatValue(balance)}</p>
+				</div>
+
+				<div>
+					<label for="crash-bet" class="mb-2 block text-sm font-medium">Bet Amount</label>
+					<div class="flex gap-2">
+						<Button
+							size="icon"
+							variant="outline"
+							class="shrink-0"
+							onclick={() => setBet(bet / 2)}
+							disabled={hasBet || roundStatus !== 'waiting'}
+							aria-label="Halve bet">½</Button
+						>
+						<Input
+							id="crash-bet"
+							type="text"
+							value={betDisplay}
+							oninput={onBetInput}
+							onblur={() => (betDisplay = bet.toLocaleString())}
+							disabled={hasBet || roundStatus !== 'waiting'}
+							placeholder="Enter bet amount"
+						/>
+						<Button
+							size="icon"
+							variant="outline"
+							class="shrink-0"
+							onclick={() => setBet(bet * 2)}
+							disabled={hasBet || roundStatus !== 'waiting'}
+							aria-label="Double bet">2×</Button
+						>
+					</div>
+					<p class="text-muted-foreground mt-1 text-xs">
+						Min bet: {formatValue(MIN_BET_AMOUNT)} • Max bet: {MAX_BET_AMOUNT.toLocaleString()}
+					</p>
+				</div>
+
+				<div class="grid grid-cols-4 gap-2">
+					{#each [0.25, 0.5, 0.75, 1] as pct}
+						<Button
+							size="sm"
+							variant="outline"
+							onclick={() => setBet(Math.floor(Math.min(balance, MAX_BET_AMOUNT) * pct))}
+							disabled={hasBet || roundStatus !== 'waiting'}
+						>
+							{pct === 1 ? 'Max' : `${pct * 100}%`}
+						</Button>
+					{/each}
+				</div>
+
+				<!-- Auto cash-out -->
+				<div class="bg-muted/40 space-y-2 rounded-lg border p-3">
+					<div class="flex items-center justify-between">
+						<label for="auto-cashout-toggle" class="flex items-center gap-1.5 text-sm font-medium">
+							<HugeiconsIcon icon={Target03Icon} class="h-4 w-4" />
+							Auto Cash Out
+						</label>
+						<Switch
+							id="auto-cashout-toggle"
+							bind:checked={autoCashoutEnabled}
+							disabled={hasBet}
+						/>
+					</div>
+					{#if autoCashoutEnabled}
+						<div class="flex items-center gap-2">
+							<Input
+								type="text"
+								value={autoCashoutDisplay}
+								oninput={onAutoCashoutInput}
+								onblur={() => (autoCashoutDisplay = autoCashoutTarget.toFixed(2))}
+								disabled={hasBet}
+								class="h-8 text-sm"
+							/>
+							<span class="text-muted-foreground text-sm">x</span>
+						</div>
+					{/if}
+				</div>
+
+				<div class="flex flex-col gap-2">
+					{#if !hasBet}
+						<Button class="h-12 w-full text-lg" onclick={placeBet} disabled={!canBet || busy}>
+							{roundStatus === 'waiting' ? 'Place Bet' : 'Betting Closed'}
+						</Button>
+					{:else if !cashedOut}
+						<Button
+							class="cashout-btn h-12 w-full text-lg"
+							onclick={cashout}
+							disabled={roundStatus !== 'running' || busy}
+						>
+							Cash Out at {currentMultiplier.toFixed(2)}x
+						</Button>
+					{:else}
+						<Button class="h-12 w-full text-lg" disabled>
+							Cashed Out at {myMultiplier.toFixed(2)}x
+						</Button>
+					{/if}
+
+					{#if hasBet}
+						<div class="bg-muted/50 space-y-2 rounded-lg p-3">
+							<div class="flex justify-between">
+								<span class="text-sm">Bet:</span>
+								<span class="text-sm font-medium">{formatValue(myBetAmount)}</span>
+							</div>
+							{#if cashedOut}
+								<div class="flex justify-between">
+									<span class="text-sm">Payout:</span>
+									<span class="text-success text-sm font-medium">{formatValue(myPayout)}</span>
+								</div>
+								<div class="flex justify-between">
+									<span class="text-sm">Multiplier:</span>
+									<span class="text-sm font-medium">{myMultiplier.toFixed(2)}x</span>
+								</div>
+							{:else}
+								<div class="flex justify-between">
+									<span class="text-sm">Current value:</span>
+									<span class="text-sm font-medium"
+										>{formatValue(myBetAmount * currentMultiplier)}</span
+									>
+								</div>
+								<div class="flex justify-between">
+									<span class="text-sm">Profit:</span>
+									<span class="text-success text-sm font-medium"
+										>+{formatValue(myBetAmount * (currentMultiplier - 1))}</span
+									>
+								</div>
+							{/if}
+						</div>
+					{/if}
+
+					{#if lastResult === 'won'}
+						<div class="rounded-lg border border-green-500/40 bg-green-500/10 p-3 text-center">
+							<p class="font-bold text-green-500">You won {formatValue(lastPayout)}!</p>
+						</div>
+					{:else if lastResult === 'lost'}
+						<div class="rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-center">
+							<p class="font-bold text-red-500">You lost {formatValue(myBetAmount)}!</p>
+						</div>
+					{/if}
+				</div>
+
+				<div class="text-muted-foreground space-y-1 text-xs">
+					<p class="flex items-center gap-1">
+						<HugeiconsIcon icon={Clock01Icon} class="h-3 w-3" />
+						Round #{roundId} • {betCount} bet{betCount === 1 ? '' : 's'} • {connected
+							? 'connected'
+							: 'reconnecting…'}
+					</p>
+					<Tooltip.Root>
+						<Tooltip.Trigger class="cursor-help break-all font-mono underline decoration-dotted">
+							Seed hash: {serverSeedHash.slice(0, 20)}…
+						</Tooltip.Trigger>
+						<Tooltip.Content class="max-w-72">
+							<p class="text-xs">
+								This round's crash point is derived from a secret server seed, revealed only
+								after the round crashes. The hash above is published in advance so you can
+								verify it wasn't changed afterwards.
+							</p>
+							{#if serverSeed}
+								<p class="text-muted-foreground mt-1 break-all font-mono text-[10px]">
+									Seed: {serverSeed}
+								</p>
+							{/if}
+						</Tooltip.Content>
+					</Tooltip.Root>
+				</div>
+			</div>
+		</div>
+	</CardContent>
+</Card>
+
+<style>
+	.crash-chart-wrap {
+		background: radial-gradient(ellipse at bottom, var(--muted) 0%, var(--background) 100%);
+		transition: box-shadow 0.2s ease;
+	}
+
+	.crash-multiplier {
+		text-shadow: 0 0 24px currentColor;
+	}
+
+	.cashout-btn {
+		animation: cashout-pulse 1.4s ease-in-out infinite;
+	}
+
+	.history-chip {
+		transition: transform 0.15s ease;
+	}
+
+	.history-chip:hover {
+		transform: translateY(-2px) scale(1.05);
+	}
+
+	@keyframes cashout-pulse {
+		0%,
+		100% {
+			box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.4);
+		}
+		50% {
+			box-shadow: 0 0 0 8px rgba(34, 197, 94, 0);
+		}
+	}
+
+	@keyframes shake {
+		10%,
+		90% {
+			transform: translateX(-1px);
+		}
+		20%,
+		80% {
+			transform: translateX(2px);
+		}
+		30%,
+		50%,
+		70% {
+			transform: translateX(-4px);
+		}
+		40%,
+		60% {
+			transform: translateX(4px);
+		}
+	}
+
+	.shake {
+		animation: shake 0.4s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+	}
+
+	.crashed-flash {
+		box-shadow: inset 0 0 60px 10px rgba(239, 68, 68, 0.35);
+	}
+</style>

--- a/website/src/lib/server/games/crash.ts
+++ b/website/src/lib/server/games/crash.ts
@@ -120,8 +120,8 @@ async function ensureRound(): Promise<CrashRound> {
 	return round;
 }
 
-async function publishRound(round: CrashRound) {
-	const payload = {
+async function publishRound(round: CrashRound, includeHistoryEntry = false) {
+	const payload: Record<string, unknown> = {
 		type: 'crash_round',
 		roundId: round.roundId,
 		status: round.status,
@@ -136,6 +136,22 @@ async function publishRound(round: CrashRound) {
 			round.status === 'running' ? crashMultiplierAt(Date.now() - round.startTime) : 1,
 		betCount: Object.keys(round.bets).length
 	};
+
+	// Only attach the history entry on the publish that immediately follows the
+	// waiting/settled transition to "crashed" — republishes of the same crashed
+	// round (e.g. after a server restart) must NOT resend it, or WS clients
+	// would duplicate the entry in their local history array.
+	if (round.status === 'crashed' && includeHistoryEntry) {
+		payload.historyEntry = {
+			roundId: round.roundId,
+			crashPoint: round.crashPoint,
+			serverSeed: round.serverSeed,
+			serverSeedHash: round.serverSeedHash,
+			nonce: round.nonce,
+			crashedAt: round.crashedAt
+		};
+	}
+
 	await redis.publish(CRASH_CHANNEL, JSON.stringify(payload));
 }
 
@@ -322,9 +338,9 @@ export async function crashAdvanceRounds() {
 			if (updated) {
 				const updatedRound = await getRound();
 				if (updatedRound) {
+					await publishRound(updatedRound, true);
 					await settleLosses(updatedRound);
 					await redis.eval(MARK_SETTLED, { keys: [CRASH_ROUND_KEY], arguments: [] });
-					await publishRound(updatedRound);
 				}
 			}
 		}

--- a/website/src/lib/server/games/crash.ts
+++ b/website/src/lib/server/games/crash.ts
@@ -1,0 +1,560 @@
+import { createHmac, randomBytes, createHash } from 'crypto';
+import { db } from '$lib/server/db';
+import { user } from '$lib/server/db/schema';
+import { eq } from 'drizzle-orm';
+import { redis } from '$lib/server/redis';
+import { publishArcadeActivity } from '$lib/server/arcade-activity';
+import { checkAndAwardAchievements } from '$lib/server/achievements';
+
+// --- CRASH Game Constants ---
+// House edge of 3% ensures the game is deflationary (prevents economy inflation).
+// P(crash >= M) = (1 - houseEdge) / M, so EV per $1 wagered = 0.97 (97% RTP).
+export const CRASH_HOUSE_EDGE = 0.03;
+// Multiplier growth rate per second: multiplier(t) = e^(rate * t)
+export const CRASH_RATE = 0.1;
+export const CRASH_WAITING_DURATION = 8000; // ms to place bets
+export const CRASH_PAUSE_DURATION = 5000; // ms after crash before next round
+export const CRASH_MAX_BET = 100_000;
+export const CRASH_MIN_BET = 0.01;
+export const CRASH_MAX_PAYOUT = 2_000_000; // anti-inflation cap per bet
+export const CRASH_MAX_POINT = 10_000; // cap crash point to keep rounds reasonable
+export const CRASH_MAX_BETS = 1000; // max bets per round
+
+export const CRASH_ROUND_KEY = 'crash:round';
+export const CRASH_HISTORY_KEY = 'crash:history';
+export const CRASH_CHANNEL = 'crash:round';
+
+export interface CrashBet {
+	userId: number;
+	betAmount: number;
+	cashedOut: boolean;
+	cashoutMultiplier: number | null;
+	payout: number | null;
+}
+
+export interface CrashRound {
+	roundId: number;
+	status: 'waiting' | 'running' | 'crashed';
+	crashPoint: number;
+	serverSeed: string;
+	serverSeedHash: string;
+	nonce: number;
+	waitingStartedAt: number;
+	startTime: number;
+	crashedAt: number;
+	settled: boolean;
+	bets: Record<string, CrashBet>;
+	lastActivity: number;
+}
+
+// --- Provably fair helpers ---
+export function generateServerSeed(): string {
+	return randomBytes(32).toString('hex');
+}
+
+export function hashServerSeed(seed: string): string {
+	return createHash('sha256').update(seed).digest('hex');
+}
+
+/**
+ * Derives the crash point from the server seed + nonce using HMAC-SHA256.
+ * The result is uniform in [0, 1), giving P(crash >= M) = (1 - houseEdge) / M.
+ */
+export function generateCrashPoint(
+	serverSeed: string,
+	nonce: number,
+	houseEdge = CRASH_HOUSE_EDGE
+): number {
+	const hmac = createHmac('sha256', serverSeed).update(String(nonce)).digest();
+	// Use 6 bytes (48-bit) integer — stays within Number.MAX_SAFE_INTEGER (2^53)
+	// to guarantee a uniform distribution in [0, 1) with no precision loss.
+	const h = hmac.readUInt32BE(0) * 2 ** 16 + hmac.readUInt16BE(4);
+	const r = h / 2 ** 48; // uniform in [0, 1)
+	const crashPoint = Math.max(1, (1 - houseEdge) / r);
+	const rounded = Math.round(crashPoint * 100) / 100;
+	return Math.min(rounded, CRASH_MAX_POINT);
+}
+
+/** Multiplier at a given elapsed time (ms) since the round started running. */
+export function crashMultiplierAt(elapsedMs: number): number {
+	if (elapsedMs <= 0) return 1;
+	return Math.floor(Math.exp(CRASH_RATE * (elapsedMs / 1000)) * 100) / 100;
+}
+
+/** Time (ms) for the multiplier to reach a given point. */
+export function crashTimeForPoint(point: number): number {
+	return (Math.log(point) / CRASH_RATE) * 1000;
+}
+
+function newRound(now: number): CrashRound {
+	const serverSeed = generateServerSeed();
+	return {
+		roundId: 1,
+		status: 'waiting',
+		crashPoint: 0,
+		serverSeed,
+		serverSeedHash: hashServerSeed(serverSeed),
+		nonce: 0,
+		waitingStartedAt: now,
+		startTime: 0,
+		crashedAt: 0,
+		settled: false,
+		bets: {},
+		lastActivity: now
+	};
+}
+
+async function getRound(): Promise<CrashRound | null> {
+	const raw = await redis.get(CRASH_ROUND_KEY);
+	return raw ? (JSON.parse(raw) as CrashRound) : null;
+}
+
+async function ensureRound(): Promise<CrashRound> {
+	const existing = await getRound();
+	if (existing) return existing;
+	const round = newRound(Date.now());
+	const result = await redis.set(CRASH_ROUND_KEY, JSON.stringify(round), { NX: true });
+	if (result === 'OK') return round;
+	const created = await getRound();
+	if (created) return created;
+	return round;
+}
+
+async function publishRound(round: CrashRound) {
+	const payload = {
+		type: 'crash_round',
+		roundId: round.roundId,
+		status: round.status,
+		crashPoint: round.status === 'crashed' ? round.crashPoint : null,
+		serverSeedHash: round.serverSeedHash,
+		serverSeed: round.status === 'crashed' ? round.serverSeed : null,
+		nonce: round.nonce,
+		waitingStartedAt: round.waitingStartedAt,
+		startTime: round.startTime,
+		crashedAt: round.crashedAt,
+		currentMultiplier:
+			round.status === 'running' ? crashMultiplierAt(Date.now() - round.startTime) : 1,
+		betCount: Object.keys(round.bets).length
+	};
+	await redis.publish(CRASH_CHANNEL, JSON.stringify(payload));
+}
+
+// --- Lua scripts (atomic Redis operations) ---
+const TRANSITION_TO_RUNNING = `
+local roundRaw = redis.call("get", KEYS[1])
+if not roundRaw then return 0 end
+local round = cjson.decode(roundRaw)
+if round.status ~= "waiting" then return 0 end
+round.status = "running"
+round.startTime = tonumber(ARGV[1])
+round.crashPoint = tonumber(ARGV[2])
+round.lastActivity = tonumber(ARGV[1])
+redis.call("set", KEYS[1], cjson.encode(round))
+return 1
+`;
+
+const TRANSITION_TO_CRASHED = `
+local roundRaw = redis.call("get", KEYS[1])
+if not roundRaw then return 0 end
+local round = cjson.decode(roundRaw)
+if round.status ~= "running" then return 0 end
+round.status = "crashed"
+round.crashedAt = tonumber(ARGV[1])
+round.settled = false
+round.lastActivity = tonumber(ARGV[1])
+redis.call("set", KEYS[1], cjson.encode(round))
+local hist = { roundId = round.roundId, crashPoint = round.crashPoint, serverSeed = round.serverSeed, serverSeedHash = round.serverSeedHash, nonce = round.nonce, crashedAt = round.crashedAt }
+redis.call("lpush", KEYS[2], cjson.encode(hist))
+redis.call("ltrim", KEYS[2], 0, 49)
+return 1
+`;
+
+const MARK_SETTLED = `
+local roundRaw = redis.call("get", KEYS[1])
+if not roundRaw then return 0 end
+local round = cjson.decode(roundRaw)
+if round.status ~= "crashed" then return 0 end
+if round.settled then return 0 end
+round.settled = true
+redis.call("set", KEYS[1], cjson.encode(round))
+return 1
+`;
+
+const START_NEW_ROUND = `
+local roundRaw = redis.call("get", KEYS[1])
+if not roundRaw then return 0 end
+local round = cjson.decode(roundRaw)
+if round.status ~= "crashed" then return 0 end
+if not round.settled then return 0 end
+local now = tonumber(ARGV[1])
+if now - round.crashedAt < tonumber(ARGV[2]) then return 0 end
+local newRound = {
+  roundId = round.roundId + 1,
+  status = "waiting",
+  crashPoint = 0,
+  serverSeed = ARGV[3],
+  serverSeedHash = ARGV[4],
+  nonce = 0,
+  waitingStartedAt = now,
+  startTime = 0,
+  crashedAt = 0,
+  settled = false,
+  bets = {},
+  lastActivity = now
+}
+redis.call("set", KEYS[1], cjson.encode(newRound))
+return 1
+`;
+
+const ADD_BET = `
+local roundRaw = redis.call("get", KEYS[1])
+if not roundRaw then return {0, "no_round"} end
+local round = cjson.decode(roundRaw)
+if round.status ~= "waiting" then return {0, "not_waiting"} end
+local betKey = "user:" .. ARGV[1]
+if round.bets[betKey] then return {0, "already_bet"} end
+local count = 0
+for k, v in pairs(round.bets) do count = count + 1 end
+if count >= tonumber(ARGV[3]) then return {0, "round_full"} end
+round.bets[betKey] = {
+  userId = tonumber(ARGV[1]),
+  betAmount = tonumber(ARGV[2]),
+  cashedOut = false
+}
+round.lastActivity = tonumber(ARGV[4])
+redis.call("set", KEYS[1], cjson.encode(round))
+return {1, "ok"}
+`;
+
+const CASHOUT = `
+local roundRaw = redis.call("get", KEYS[1])
+if not roundRaw then return {0, "no_round"} end
+local round = cjson.decode(roundRaw)
+if round.status ~= "running" then return {0, "not_running"} end
+local betKey = "user:" .. ARGV[1]
+local bet = round.bets[betKey]
+if not bet then return {0, "no_bet"} end
+if bet.cashedOut then return {0, "already_cashed"} end
+local now = tonumber(ARGV[2])
+local rate = tonumber(ARGV[4])
+local elapsed = (now - round.startTime) / 1000
+local mult = math.floor(math.exp(rate * elapsed) * 100) / 100
+if mult >= round.crashPoint then return {0, "crashed"} end
+local payout = math.floor(bet.betAmount * mult * 100000000) / 100000000
+local maxPayout = tonumber(ARGV[3])
+if payout > maxPayout then payout = maxPayout end
+bet.cashedOut = true
+bet.cashoutMultiplier = mult
+bet.payout = payout
+round.bets[betKey] = bet
+round.lastActivity = now
+redis.call("set", KEYS[1], cjson.encode(round))
+return {1, tostring(payout), tostring(mult), tostring(bet.betAmount)}
+`;
+
+// --- Settlement of losing bets when a round crashes ---
+async function settleLosses(round: CrashRound) {
+	const uncashed = Object.values(round.bets).filter((b) => !b.cashedOut);
+	for (const bet of uncashed) {
+		try {
+			await db.transaction(async (tx) => {
+				const [row] = await tx
+					.select({
+						arcadeLosses: user.arcadeLosses,
+						totalArcadeGamesPlayed: user.totalArcadeGamesPlayed,
+						arcadeWinStreak: user.arcadeWinStreak,
+						totalArcadeWagered: user.totalArcadeWagered
+					})
+					.from(user)
+					.where(eq(user.id, bet.userId))
+					.for('update')
+					.limit(1);
+				if (!row) return;
+				await tx
+					.update(user)
+					.set({
+						arcadeLosses: `${Number(row.arcadeLosses || 0) + bet.betAmount}`,
+						totalArcadeGamesPlayed: (row.totalArcadeGamesPlayed || 0) + 1,
+						totalArcadeWagered: `${Number(row.totalArcadeWagered || 0) + bet.betAmount}`,
+						arcadeWinStreak: 0,
+						updatedAt: new Date()
+					})
+					.where(eq(user.id, bet.userId));
+			});
+
+			if (bet.betAmount >= 1000) {
+				await publishArcadeActivity(bet.userId, bet.betAmount, false, 'crash', 0);
+			}
+			await checkAndAwardAchievements(bet.userId, ['arcade'], {
+				arcadeWon: false,
+				arcadeWager: bet.betAmount
+			});
+		} catch (e) {
+			console.error(`Failed to settle crash loss for user ${bet.userId}:`, e);
+		}
+	}
+}
+
+// --- Round advancement (called by the scheduler) ---
+export async function crashAdvanceRounds() {
+	const now = Date.now();
+	const round = await ensureRound();
+
+	if (round.status === 'waiting') {
+		if (now - round.waitingStartedAt >= CRASH_WAITING_DURATION) {
+			const crashPoint = generateCrashPoint(round.serverSeed, round.nonce);
+			const updated = (await redis.eval(TRANSITION_TO_RUNNING, {
+				keys: [CRASH_ROUND_KEY],
+				arguments: [String(now), String(crashPoint)]
+			})) as number;
+			if (updated) {
+				const updatedRound = await getRound();
+				if (updatedRound) await publishRound(updatedRound);
+			}
+		}
+	} else if (round.status === 'running') {
+		const currentMult = crashMultiplierAt(now - round.startTime);
+		if (currentMult >= round.crashPoint) {
+			const updated = (await redis.eval(TRANSITION_TO_CRASHED, {
+				keys: [CRASH_ROUND_KEY, CRASH_HISTORY_KEY],
+				arguments: [String(now)]
+			})) as number;
+			if (updated) {
+				const updatedRound = await getRound();
+				if (updatedRound) {
+					await settleLosses(updatedRound);
+					await redis.eval(MARK_SETTLED, { keys: [CRASH_ROUND_KEY], arguments: [] });
+					await publishRound(updatedRound);
+				}
+			}
+		}
+	} else if (round.status === 'crashed') {
+		if (!round.settled) {
+			await settleLosses(round);
+			await redis.eval(MARK_SETTLED, { keys: [CRASH_ROUND_KEY], arguments: [] });
+			const updatedRound = await getRound();
+			if (updatedRound) await publishRound(updatedRound);
+		} else if (now - round.crashedAt >= CRASH_PAUSE_DURATION) {
+			const serverSeed = generateServerSeed();
+			const updated = (await redis.eval(START_NEW_ROUND, {
+				keys: [CRASH_ROUND_KEY],
+				arguments: [
+					String(now),
+					String(CRASH_PAUSE_DURATION),
+					serverSeed,
+					hashServerSeed(serverSeed)
+				]
+			})) as number;
+			if (updated) {
+				const updatedRound = await getRound();
+				if (updatedRound) await publishRound(updatedRound);
+			}
+		}
+	}
+}
+
+// --- Public API helpers ---
+export async function placeCrashBet(
+	userId: number,
+	betAmount: number
+): Promise<{ newBalance: number; roundId: number }> {
+	const now = Date.now();
+
+	// 1. Debit the bet in a DB transaction (row lock)
+	const newBalance = await db.transaction(async (tx) => {
+		const [row] = await tx
+			.select({ baseCurrencyBalance: user.baseCurrencyBalance })
+			.from(user)
+			.where(eq(user.id, userId))
+			.for('update')
+			.limit(1);
+		if (!row) throw new Error('User not found');
+		const balance = Math.round(Number(row.baseCurrencyBalance) * 100000000) / 100000000;
+		if (betAmount > balance) {
+			throw new Error(
+				`Insufficient funds. You need $${betAmount.toFixed(2)} but only have $${balance.toFixed(2)}`
+			);
+		}
+		const newBal = Math.round((balance - betAmount) * 100000000) / 100000000;
+		await tx
+			.update(user)
+			.set({ baseCurrencyBalance: newBal.toFixed(8), updatedAt: new Date() })
+			.where(eq(user.id, userId));
+		return newBal;
+	});
+
+	// 2. Atomically add the bet to the Redis round (only if waiting)
+	// NB: Refund on ANY failure (including a Lua script exception) so the
+	// player's balance is never debited without a bet being recorded.
+	const refundBet = async () => {
+		await db.transaction(async (tx) => {
+			const [row] = await tx
+				.select({ baseCurrencyBalance: user.baseCurrencyBalance })
+				.from(user)
+				.where(eq(user.id, userId))
+				.for('update')
+				.limit(1);
+			if (row) {
+				const balance = Math.round(Number(row.baseCurrencyBalance) * 100000000) / 100000000;
+				const newBal = Math.round((balance + betAmount) * 100000000) / 100000000;
+				await tx
+					.update(user)
+					.set({ baseCurrencyBalance: newBal.toFixed(8), updatedAt: new Date() })
+					.where(eq(user.id, userId));
+			}
+		});
+	};
+
+	let errorMessage: string | null = null;
+
+	try {
+		const result = (await redis.eval(ADD_BET, {
+			keys: [CRASH_ROUND_KEY],
+			arguments: [String(userId), String(betAmount), String(CRASH_MAX_BETS), String(now)]
+		})) as [number, string];
+
+		if (result[0] === 1) {
+			const round = await getRound();
+			return { newBalance, roundId: round?.roundId ?? 0 };
+		}
+
+		errorMessage =
+			result[1] === 'not_waiting'
+				? 'Betting is closed for this round'
+				: result[1] === 'already_bet'
+					? 'You already have a bet in this round'
+					: result[1] === 'round_full'
+						? 'This round is full'
+						: 'Unable to place bet';
+	} catch (e) {
+		console.error('Crash ADD_BET error, refunding bet:', e);
+		errorMessage = 'Unable to place bet';
+	}
+
+	// Bet was not successfully recorded — refund the debited amount.
+	await refundBet();
+	throw new Error(errorMessage);
+}
+
+export async function cashoutCrashBet(
+	userId: number
+): Promise<{ payout: number; multiplier: number; betAmount: number; newBalance: number }> {
+	const now = Date.now();
+	const result = (await redis.eval(CASHOUT, {
+		keys: [CRASH_ROUND_KEY],
+		arguments: [String(userId), String(now), String(CRASH_MAX_PAYOUT), String(CRASH_RATE)]
+	})) as [number, string, string, string];
+
+	if (result[0] !== 1) {
+		const code = result[1];
+		throw new Error(
+			code === 'crashed'
+				? 'The round has crashed'
+				: code === 'not_running'
+					? 'The round is not running'
+					: code === 'already_cashed'
+						? 'You already cashed out'
+						: code === 'no_bet'
+							? 'You have no active bet in this round'
+							: 'Unable to cash out'
+		);
+	}
+
+	const payout = parseFloat(result[1]);
+	const multiplier = parseFloat(result[2]);
+	const betAmount = parseFloat(result[3]);
+	const net = Math.round((payout - betAmount) * 100000000) / 100000000;
+
+	// Credit the payout in a DB transaction (row lock)
+	const newBalance = await db.transaction(async (tx) => {
+		const [row] = await tx
+			.select({
+				baseCurrencyBalance: user.baseCurrencyBalance,
+				arcadeWins: user.arcadeWins,
+				arcadeWinStreak: user.arcadeWinStreak,
+				arcadeBestWinStreak: user.arcadeBestWinStreak,
+				totalArcadeGamesPlayed: user.totalArcadeGamesPlayed,
+				totalArcadeWagered: user.totalArcadeWagered
+			})
+			.from(user)
+			.where(eq(user.id, userId))
+			.for('update')
+			.limit(1);
+		if (!row) throw new Error('User not found');
+		const balance = Math.round(Number(row.baseCurrencyBalance) * 100000000) / 100000000;
+		const newBal = Math.round((balance + payout) * 100000000) / 100000000;
+		const won = net > 0;
+
+		const update: Record<string, unknown> = {
+			baseCurrencyBalance: newBal.toFixed(8),
+			totalArcadeGamesPlayed: (row.totalArcadeGamesPlayed || 0) + 1,
+			totalArcadeWagered: `${Number(row.totalArcadeWagered || 0) + betAmount}`,
+			updatedAt: new Date()
+		};
+
+		if (won) {
+			update.arcadeWins = `${Number(row.arcadeWins || 0) + net}`;
+			const streak = (row.arcadeWinStreak || 0) + 1;
+			update.arcadeWinStreak = streak;
+			update.arcadeBestWinStreak = Math.max(streak, row.arcadeBestWinStreak || 0);
+		}
+
+		await tx.update(user).set(update).where(eq(user.id, userId));
+		return newBal;
+	});
+
+	// Publish arcade activity for wins >= $1000
+	if (payout >= 1000) {
+		await publishArcadeActivity(userId, payout, true, 'crash', 0);
+	}
+	await checkAndAwardAchievements(userId, ['arcade'], {
+		arcadeWon: true,
+		arcadeWager: betAmount
+	});
+
+	return { payout, multiplier, betAmount, newBalance };
+}
+
+export async function getCrashState(userId: number | null) {
+	const round = await getRound();
+	if (!round) {
+		return { round: null, userBet: null, history: [] };
+	}
+
+	const currentMultiplier =
+		round.status === 'running' ? crashMultiplierAt(Date.now() - round.startTime) : 1;
+
+	const userBet = userId ? round.bets[`user:${userId}`] : null;
+
+	const historyRaw = (await redis.lRange(
+		CRASH_HISTORY_KEY,
+		0,
+		49
+	)) as unknown as string[] | null;
+	const history = (historyRaw ?? []).map((h) => JSON.parse(h));
+
+	return {
+		round: {
+			roundId: round.roundId,
+			status: round.status,
+			crashPoint: round.status === 'crashed' ? round.crashPoint : null,
+			serverSeedHash: round.serverSeedHash,
+			serverSeed: round.status === 'crashed' ? round.serverSeed : null,
+			nonce: round.nonce,
+			waitingStartedAt: round.waitingStartedAt,
+			startTime: round.startTime,
+			crashedAt: round.crashedAt,
+			currentMultiplier,
+			betCount: Object.keys(round.bets).length
+		},
+		userBet: userBet
+			? {
+					betAmount: userBet.betAmount,
+					cashedOut: userBet.cashedOut,
+					cashoutMultiplier: userBet.cashoutMultiplier,
+					payout: userBet.payout
+				}
+			: null,
+		history
+	};
+}

--- a/website/src/routes/api/arcade/crash/bet/+server.ts
+++ b/website/src/routes/api/arcade/crash/bet/+server.ts
@@ -1,0 +1,38 @@
+import { auth } from '$lib/auth';
+import { error, json } from '@sveltejs/kit';
+import { placeCrashBet, CRASH_MAX_BET, CRASH_MIN_BET } from '$lib/server/games/crash';
+import { validateBetAmount } from '$lib/utils';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ request }) => {
+    const session = await auth.api.getSession({ headers: request.headers });
+    if (!session?.user) throw error(401, 'Not authenticated');
+
+    try {
+        const { amount } = await request.json();
+        const userId = Number(session.user.id);
+
+        const bet = validateBetAmount(amount, CRASH_MIN_BET, CRASH_MAX_BET);
+
+        const result = await placeCrashBet(userId, bet);
+        return json(result);
+    } catch (e) {
+        if (e instanceof Error && e.message.startsWith('Insufficient funds')) {
+            return json({ error: e.message }, { status: 400 });
+        }
+        if (e instanceof Error && e.message.includes('Betting is closed')) {
+            return json({ error: e.message }, { status: 400 });
+        }
+        if (e instanceof Error && e.message.includes('already have a bet')) {
+            return json({ error: e.message }, { status: 400 });
+        }
+        if (e instanceof Error && e.message.includes('round is full')) {
+            return json({ error: e.message }, { status: 400 });
+        }
+        if (e instanceof Error && e.message.startsWith('Bet amount')) {
+            return json({ error: e.message }, { status: 400 });
+        }
+        console.error('Crash bet error:', e);
+        return json({ error: 'Internal server error' }, { status: 500 });
+    }
+};

--- a/website/src/routes/api/arcade/crash/cashout/+server.ts
+++ b/website/src/routes/api/arcade/crash/cashout/+server.ts
@@ -1,0 +1,29 @@
+import { auth } from '$lib/auth';
+import { error, json } from '@sveltejs/kit';
+import { cashoutCrashBet } from '$lib/server/games/crash';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ request }) => {
+    const session = await auth.api.getSession({ headers: request.headers });
+    if (!session?.user) throw error(401, 'Not authenticated');
+
+    try {
+        const userId = Number(session.user.id);
+        const result = await cashoutCrashBet(userId);
+        return json(result);
+    } catch (e) {
+        if (e instanceof Error) {
+            const msg = e.message;
+            if (
+                msg.includes('crashed') ||
+                msg.includes('not running') ||
+                msg.includes('already cashed') ||
+                msg.includes('no active bet')
+            ) {
+                return json({ error: msg }, { status: 400 });
+            }
+        }
+        console.error('Crash cashout error:', e);
+        return json({ error: 'Internal server error' }, { status: 500 });
+    }
+};

--- a/website/src/routes/api/arcade/crash/state/+server.ts
+++ b/website/src/routes/api/arcade/crash/state/+server.ts
@@ -1,0 +1,17 @@
+import { auth } from '$lib/auth';
+import { error, json } from '@sveltejs/kit';
+import { getCrashState } from '$lib/server/games/crash';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ request }) => {
+    const session = await auth.api.getSession({ headers: request.headers });
+    const userId = session?.user ? Number(session.user.id) : null;
+
+    try {
+        const state = await getCrashState(userId);
+        return json(state);
+    } catch (e) {
+        console.error('Crash state error:', e);
+        return json({ error: 'Internal server error' }, { status: 500 });
+    }
+};

--- a/website/src/routes/arcade/+page.svelte
+++ b/website/src/routes/arcade/+page.svelte
@@ -9,6 +9,7 @@
 	import SEO from '$lib/components/self/SEO.svelte';
 	import Dice from '$lib/components/self/games/Dice.svelte';
 	import Tower from '$lib/components/self/games/Tower.svelte';
+	import Crash from '$lib/components/self/games/Crash.svelte';
 	import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '$lib/components/ui/card';
 	import { arcadeActivityStore } from '$lib/stores/websocket';
 	import * as Avatar from '$lib/components/ui/avatar';
@@ -103,6 +104,12 @@
 				>
 					Tower
 				</Button>
+				<Button
+					variant={activeGame === 'crash' ? 'default' : 'outline'}
+					onclick={() => (activeGame = 'crash')}
+				>
+					Crash
+				</Button>
 			</div>
 
 			<!-- Game Content -->
@@ -116,6 +123,8 @@
 				<Dice bind:balance onBalanceUpdate={handleBalanceUpdate} />
 			{:else if activeGame === 'tower'}
 				<Tower bind:balance onBalanceUpdate={handleBalanceUpdate} />
+			{:else if activeGame === 'crash'}
+				<Crash bind:balance onBalanceUpdate={handleBalanceUpdate} />
 			{/if}
 
 			<!-- Live Arcade Activity Feed -->

--- a/website/websocket/bun.lock
+++ b/website/websocket/bun.lock
@@ -1,0 +1,269 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "websocket",
+      "dependencies": {
+        "@sveltejs/adapter-node": "^5.2.12",
+        "dotenv": "^16.5.0",
+        "ioredis": "^5.6.1",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.5", "", { "os": "android", "cpu": "arm" }, "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.5", "", { "os": "android", "cpu": "arm64" }, "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.5", "", { "os": "android", "cpu": "x64" }, "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.5", "", { "os": "linux", "cpu": "arm" }, "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.5", "", { "os": "linux", "cpu": "none" }, "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.5", "", { "os": "linux", "cpu": "none" }, "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.5", "", { "os": "linux", "cpu": "none" }, "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.5", "", { "os": "linux", "cpu": "x64" }, "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.5", "", { "os": "none", "cpu": "arm64" }, "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.5", "", { "os": "none", "cpu": "x64" }, "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.5", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.5", "", { "os": "win32", "cpu": "x64" }, "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g=="],
+
+    "@ioredis/commands": ["@ioredis/commands@1.2.0", "", {}, ""],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.8", "", { "dependencies": { "@jridgewell/set-array": "^1.2.1", "@jridgewell/sourcemap-codec": "^1.4.10", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/set-array": ["@jridgewell/set-array@1.2.1", "", {}, "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+
+    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
+    "@rollup/plugin-commonjs": ["@rollup/plugin-commonjs@28.0.3", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "commondir": "^1.0.1", "estree-walker": "^2.0.2", "fdir": "^6.2.0", "is-reference": "1.2.1", "magic-string": "^0.30.3", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^2.68.0||^3.0.0||^4.0.0" } }, "sha512-pyltgilam1QPdn+Zd9gaCfOLcnjMEJ9gV+bTw6/r73INdvzf1ah9zLIJBm+kW7R6IUFIQ1YO+VqZtYxZNWFPEQ=="],
+
+    "@rollup/plugin-json": ["@rollup/plugin-json@6.1.0", "", { "dependencies": { "@rollup/pluginutils": "^5.1.0" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" } }, "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA=="],
+
+    "@rollup/plugin-node-resolve": ["@rollup/plugin-node-resolve@16.0.1", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "@types/resolve": "1.20.2", "deepmerge": "^4.2.2", "is-module": "^1.0.0", "resolve": "^1.22.1" }, "peerDependencies": { "rollup": "^2.78.0||^3.0.0||^4.0.0" } }, "sha512-tk5YCxJWIG81umIvNkSod2qK5KyQW19qcBF/B78n1bjtOON6gzKoVeSzAE8yHCZEDmqkHKkxplExA8KzdJLJpA=="],
+
+    "@rollup/pluginutils": ["@rollup/pluginutils@5.1.4", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" } }, "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.41.1", "", { "os": "android", "cpu": "arm" }, "sha512-NELNvyEWZ6R9QMkiytB4/L4zSEaBC03KIXEghptLGLZWJ6VPrL63ooZQCOnlx36aQPGhzuOMwDerC1Eb2VmrLw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.41.1", "", { "os": "android", "cpu": "arm64" }, "sha512-DXdQe1BJ6TK47ukAoZLehRHhfKnKg9BjnQYUu9gzhI8Mwa1d2fzxA1aw2JixHVl403bwp1+/o/NhhHtxWJBgEA=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.41.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5afxvwszzdulsU2w8JKWwY8/sJOLPzf0e1bFuvcW5h9zsEg+RQAojdW0ux2zyYAz7R8HvvzKCjLNJhVq965U7w=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.41.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-egpJACny8QOdHNNMZKf8xY0Is6gIMz+tuqXlusxquWu3F833DcMwmGM7WlvCO9sB3OsPjdC4U0wHw5FabzCGZg=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.41.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-DBVMZH5vbjgRk3r0OzgjS38z+atlupJ7xfKIDJdZZL6sM6wjfDNo64aowcLPKIx7LMQi8vybB56uh1Ftck/Atg=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.41.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-3FkydeohozEskBxNWEIbPfOE0aqQgB6ttTkJ159uWOFn42VLyfAiyD9UK5mhu+ItWzft60DycIN1Xdgiy8o/SA=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.41.1", "", { "os": "linux", "cpu": "arm" }, "sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.41.1", "", { "os": "linux", "cpu": "arm" }, "sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.41.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.41.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg=="],
+
+    "@rollup/rollup-linux-loongarch64-gnu": ["@rollup/rollup-linux-loongarch64-gnu@4.41.1", "", { "os": "linux", "cpu": "none" }, "sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw=="],
+
+    "@rollup/rollup-linux-powerpc64le-gnu": ["@rollup/rollup-linux-powerpc64le-gnu@4.41.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.41.1", "", { "os": "linux", "cpu": "none" }, "sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.41.1", "", { "os": "linux", "cpu": "none" }, "sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.41.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.41.1", "", { "os": "linux", "cpu": "x64" }, "sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.41.1", "", { "os": "linux", "cpu": "x64" }, "sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.41.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.41.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-+psFT9+pIh2iuGsxFYYa/LhS5MFKmuivRsx9iPJWNSGbh2XVEjk90fmpUEjCnILPEPJnikAU6SFDiEUyOv90Pg=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.41.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Wq2zpapRYLfi4aKxf2Xff0tN+7slj2d4R87WEzqw7ZLsVvO5zwYCIuEGSZYiK41+GlwUo1HiR+GdkLEJnCKTCw=="],
+
+    "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.5", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ=="],
+
+    "@sveltejs/adapter-node": ["@sveltejs/adapter-node@5.2.12", "", { "dependencies": { "@rollup/plugin-commonjs": "^28.0.1", "@rollup/plugin-json": "^6.1.0", "@rollup/plugin-node-resolve": "^16.0.0", "rollup": "^4.9.5" }, "peerDependencies": { "@sveltejs/kit": "^2.4.0" } }, "sha512-0bp4Yb3jKIEcZWVcJC/L1xXp9zzJS4hDwfb4VITAkfT4OVdkspSHsx7YhqJDbb2hgLl6R9Vs7VQR+fqIVOxPUQ=="],
+
+    "@sveltejs/kit": ["@sveltejs/kit@2.21.1", "", { "dependencies": { "@sveltejs/acorn-typescript": "^1.0.5", "@types/cookie": "^0.6.0", "acorn": "^8.14.1", "cookie": "^0.6.0", "devalue": "^5.1.0", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "sade": "^1.8.1", "set-cookie-parser": "^2.6.0", "sirv": "^3.0.0" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "vite": "^5.0.3 || ^6.0.0" }, "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-vLbtVwtDcK8LhJKnFkFYwM0uCdFmzioQnif0bjEYH1I24Arz22JPr/hLUiXGVYAwhu8INKx5qrdvr4tHgPwX6w=="],
+
+    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@5.0.3", "", { "dependencies": { "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1", "debug": "^4.4.0", "deepmerge": "^4.3.1", "kleur": "^4.1.5", "magic-string": "^0.30.15", "vitefu": "^1.0.4" }, "peerDependencies": { "svelte": "^5.0.0", "vite": "^6.0.0" } }, "sha512-MCFS6CrQDu1yGwspm4qtli0e63vaPCehf6V7pIMP15AsWgMKrqDGCPFF/0kn4SP0ii4aySu4Pa62+fIRGFMjgw=="],
+
+    "@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@4.0.1", "", { "dependencies": { "debug": "^4.3.7" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^5.0.0", "svelte": "^5.0.0", "vite": "^6.0.0" } }, "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw=="],
+
+    "@types/bun": ["@types/bun@1.2.15", "", { "dependencies": { "bun-types": "1.2.15" } }, "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA=="],
+
+    "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
+
+    "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
+
+    "@types/node": ["@types/node@22.15.21", "", { "dependencies": { "undici-types": "~6.21.0" } }, ""],
+
+    "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
+
+    "acorn": ["acorn@8.14.1", "", { "bin": "bin/acorn" }, "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, ""],
+
+    "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
+
+    "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
+
+    "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, ""],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "denque": ["denque@2.1.0", "", {}, ""],
+
+    "devalue": ["devalue@5.1.1", "", {}, "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw=="],
+
+    "dotenv": ["dotenv@16.5.0", "", {}, ""],
+
+    "esbuild": ["esbuild@0.25.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.5", "@esbuild/android-arm": "0.25.5", "@esbuild/android-arm64": "0.25.5", "@esbuild/android-x64": "0.25.5", "@esbuild/darwin-arm64": "0.25.5", "@esbuild/darwin-x64": "0.25.5", "@esbuild/freebsd-arm64": "0.25.5", "@esbuild/freebsd-x64": "0.25.5", "@esbuild/linux-arm": "0.25.5", "@esbuild/linux-arm64": "0.25.5", "@esbuild/linux-ia32": "0.25.5", "@esbuild/linux-loong64": "0.25.5", "@esbuild/linux-mips64el": "0.25.5", "@esbuild/linux-ppc64": "0.25.5", "@esbuild/linux-riscv64": "0.25.5", "@esbuild/linux-s390x": "0.25.5", "@esbuild/linux-x64": "0.25.5", "@esbuild/netbsd-arm64": "0.25.5", "@esbuild/netbsd-x64": "0.25.5", "@esbuild/openbsd-arm64": "0.25.5", "@esbuild/openbsd-x64": "0.25.5", "@esbuild/sunos-x64": "0.25.5", "@esbuild/win32-arm64": "0.25.5", "@esbuild/win32-ia32": "0.25.5", "@esbuild/win32-x64": "0.25.5" }, "bin": "bin/esbuild" }, "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ=="],
+
+    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
+
+    "esrap": ["esrap@1.4.6", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw=="],
+
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "fdir": ["fdir@6.4.5", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "ioredis": ["ioredis@5.6.1", "", { "dependencies": { "@ioredis/commands": "^1.1.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, ""],
+
+    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
+
+    "is-module": ["is-module@1.0.0", "", {}, "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g=="],
+
+    "is-reference": ["is-reference@1.2.1", "", { "dependencies": { "@types/estree": "*" } }, "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
+
+    "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, ""],
+
+    "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, ""],
+
+    "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, ""],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
+
+    "postcss": ["postcss@8.5.4", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w=="],
+
+    "redis-errors": ["redis-errors@1.2.0", "", {}, ""],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, ""],
+
+    "resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": "bin/resolve" }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
+
+    "rollup": ["rollup@4.41.1", "", { "dependencies": { "@types/estree": "1.0.7" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.41.1", "@rollup/rollup-android-arm64": "4.41.1", "@rollup/rollup-darwin-arm64": "4.41.1", "@rollup/rollup-darwin-x64": "4.41.1", "@rollup/rollup-freebsd-arm64": "4.41.1", "@rollup/rollup-freebsd-x64": "4.41.1", "@rollup/rollup-linux-arm-gnueabihf": "4.41.1", "@rollup/rollup-linux-arm-musleabihf": "4.41.1", "@rollup/rollup-linux-arm64-gnu": "4.41.1", "@rollup/rollup-linux-arm64-musl": "4.41.1", "@rollup/rollup-linux-loongarch64-gnu": "4.41.1", "@rollup/rollup-linux-powerpc64le-gnu": "4.41.1", "@rollup/rollup-linux-riscv64-gnu": "4.41.1", "@rollup/rollup-linux-riscv64-musl": "4.41.1", "@rollup/rollup-linux-s390x-gnu": "4.41.1", "@rollup/rollup-linux-x64-gnu": "4.41.1", "@rollup/rollup-linux-x64-musl": "4.41.1", "@rollup/rollup-win32-arm64-msvc": "4.41.1", "@rollup/rollup-win32-ia32-msvc": "4.41.1", "@rollup/rollup-win32-x64-msvc": "4.41.1", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-cPmwD3FnFv8rKMBc1MxWCwVQFxwf1JEmSX3iQXrRVVG15zerAIXRjMFVWnd5Q5QvgKF7Aj+5ykXFhUl+QGnyOw=="],
+
+    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.1", "", {}, "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="],
+
+    "sirv": ["sirv@3.0.1", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, ""],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "svelte": ["svelte@5.33.10", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^1.4.6", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-/yArPQIBoQS2p86LKnvJywOXkVHeEXnFgrDPSxkEfIAEkykopYuy2bF6UUqHG4IbZlJD6OurLxJT8Kn7kTk9WA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
+
+    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
+
+    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, ""],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, ""],
+
+    "vite": ["vite@6.3.5", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": "bin/vite.js" }, "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ=="],
+
+    "vitefu": ["vitefu@1.0.6", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0" } }, "sha512-+Rex1GlappUyNN6UfwbVZne/9cYC4+R2XDk9xkNXBKMw6HQagdX9PgZ8V2v1WUSK1wfBLp7qbI1+XSNIlB1xmA=="],
+
+    "zimmerframe": ["zimmerframe@1.1.2", "", {}, "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w=="],
+
+    "svelte/is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+  }
+}

--- a/website/websocket/src/main.ts
+++ b/website/websocket/src/main.ts
@@ -24,6 +24,7 @@ type WebSocketData = {
 
 const coinSockets = new Map<string, Set<ServerWebSocket<WebSocketData>>>();
 const userSockets = new Map<string, Set<ServerWebSocket<WebSocketData>>>();
+const allSockets = new Set<ServerWebSocket<WebSocketData>>();
 const pingIntervals = new WeakMap<ServerWebSocket<WebSocketData>, NodeJS.Timeout>();
 
 redis.on('error', (err) => console.error('Redis Client Error', err));
@@ -34,7 +35,7 @@ redis.on('connect', () => {
 		else console.log(`Successfully psubscribed to patterns. Active psubscriptions: ${count}`);
 	});
 
-	redis.subscribe('trades:all', 'trades:large', 'arcade:activity', (err, count) => {
+	redis.subscribe('trades:all', 'trades:large', 'arcade:activity', 'crash:round', (err, count) => {
 		if (err) console.error("Failed to subscribe to channels", err);
 		else console.log(`Successfully subscribed to channels. Active subscriptions: ${count}`);
 	});
@@ -102,28 +103,28 @@ redis.on('message', (channel, msg) => {
 					}
 				}
 			}
-		} else if (channel === 'arcade:activity') {
+		} else if (channel === 'arcade:activity' || channel === 'crash:round') {
 			const eventData = JSON.parse(msg);
 			const eventMessage = JSON.stringify({
-				type: 'arcade_activity',
+				type: channel === 'crash:round' ? 'crash_round' : 'arcade_activity',
 				...eventData
 			});
 
-			const allSockets = new Set<ServerWebSocket<WebSocketData>>();
+			const sockets = new Set<ServerWebSocket<WebSocketData>>(allSockets);
 
-			for (const [, sockets] of coinSockets.entries()) {
-				for (const ws of sockets) {
-					allSockets.add(ws);
+			for (const [, set] of coinSockets.entries()) {
+				for (const ws of set) {
+					sockets.add(ws);
 				}
 			}
 
-			for (const [, sockets] of userSockets.entries()) {
-				for (const ws of sockets) {
-					allSockets.add(ws);
+			for (const [, set] of userSockets.entries()) {
+				for (const ws of set) {
+					sockets.add(ws);
 				}
 			}
 
-			for (const ws of allSockets) {
+			for (const ws of sockets) {
 				if (ws.readyState === WebSocket.OPEN) {
 					ws.send(eventMessage);
 				}
@@ -237,6 +238,8 @@ const server = Bun.serve<WebSocketData, undefined>({
 			}
 		},
 		open(ws) {
+			allSockets.add(ws);
+
 			const interval = setInterval(() => {
 				if (ws.readyState === 1) {
 					ws.data.lastActivity = Date.now();
@@ -248,6 +251,8 @@ const server = Bun.serve<WebSocketData, undefined>({
 
 			pingIntervals.set(ws, interval);
 		}, close(ws) {
+			allSockets.delete(ws);
+
 			const interval = pingIntervals.get(ws);
 			if (interval) {
 				clearInterval(interval);


### PR DESCRIPTION
## What is Crash?

A real-time multiplayer betting game. A multiplier starts at `1.00x` and climbs on an exponential curve. Everyone who bet in that round watches the same curve rise live, and can cash out at any moment to lock in `bet × currentMultiplier`. At a random point the round "crashes" — anyone who didn't cash out before that point loses their bet.

## Round lifecycle

Rounds cycle through three states, driven server-side by a 500ms scheduler tick (`crashAdvanceRounds`, guarded by the existing Redis scheduler lock so only one server instance runs it):

1. **`waiting`** (8s) — betting window is open. Players place one bet each.
2. **`running`** — the multiplier climbs as `e^(0.1 × secondsElapsed)` (≈2x at 6.9s, 5x at 16s, 10x at 23s). Players can cash out at any point.
3. **`crashed`** (5s pause) — the round's target crash point is revealed, uncashed bets are settled as losses, then a new round begins.

State lives in a single Redis key (`crash:round`) as JSON, and every transition is applied through an atomic Lua script (compare-and-swap on `status`) so two server instances or two simultaneous requests can never double-apply a transition, double-cash a bet, or process a bet after the round already moved on.

## How the crash point is decided — provably fair

Before a round even starts, the server generates a random 32-byte `serverSeed` and publishes only its SHA-256 **hash**. Players see the hash immediately but not the seed itself — so the outcome is fixed and cannot be changed by the house *after* people start betting, but *also* cannot be predicted by players in advance.

```
crashPoint = min( (1 - houseEdge) / r , MAX_POINT )   where r = HMAC-SHA256(serverSeed, nonce) as a float in [0, 1)
```

Once the round crashes, the real `serverSeed` is revealed in the round history. Anyone can then recompute the HMAC themselves and confirm the crash point matches the hash that was published beforehand — that's the "provably fair" guarantee. This math gives a clean `P(crash ≥ M) = (1 - houseEdge) / M`, i.e. a flat **3% house edge** (97% RTP) at every multiplier.

## Money flow & safety

- **Placing a bet**: balance is debited in a Postgres row-locked transaction, *then* the bet is atomically added to the round in Redis. If the Redis step fails or the round already closed, the debit is automatically refunded — the player is never charged without a recorded bet.
- **Cashing out**: the payout multiplier is computed **server-side inside the Lua script**, never trusted from the client, and capped so it can never exceed the actual crash point or the round's crash multiplier. Balance is credited in a locked DB transaction.
- **Anti-abuse caps**: max bet $100k, max payout $2M/bet, max crash point 10,000x, max 1,000 bets/round, plus the existing `/api/arcade/` rate limit (10 req/5s).
- Losing bets are settled automatically when a round crashes (loops over everyone who didn't cash out and debits their stats), so there's no way to "forget" to resolve a bet.

## Real-time sync

The websocket server subscribes to a `crash:round` Redis channel. Every state transition (round starts, starts running, crashes, resets) is published once and broadcast to all connected clients, so everyone's chart, countdown, and multiplier stay in lockstep without polling.

<img width="1224" height="647" alt="image" src="https://github.com/user-attachments/assets/355d0c4e-ffd6-4b00-a51a-93cf544526f8" />
<img width="1292" height="591" alt="image" src="https://github.com/user-attachments/assets/8d9dc356-d492-429c-8751-e09fb58280f2" />
