### PR TITLE
Round one: API credits fix, buy-by-tokens, recent trades, Wheel of Fortune

### DIFF
--- a/website/src/lib/components/self/CoinTrades.svelte
+++ b/website/src/lib/components/self/CoinTrades.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card';
+	import * as Avatar from '$lib/components/ui/avatar';
+	import { HugeiconsIcon } from '@hugeicons/svelte';
+	import { TradeUpIcon, TradeDownIcon, Clock01Icon, Activity01Icon } from '@hugeicons/core-free-icons';
+	import { goto } from '$app/navigation';
+	import { getPublicUrl, formatValue, formatRelativeTime } from '$lib/utils';
+
+	interface RecentTrade {
+		type: 'BUY' | 'SELL';
+		username: string;
+		userImage?: string;
+		amount: number;
+		totalValue: number;
+		price: number;
+		timestamp: number;
+		userId: string;
+	}
+
+	let { coinSymbol } = $props<{ coinSymbol: string }>();
+
+	let loading = $state(true);
+	let trades = $state<RecentTrade[]>([]);
+
+	async function fetchTrades() {
+		try {
+			const response = await fetch(
+				`/api/trades/recent?coin=${encodeURIComponent(coinSymbol)}&limit=10`
+			);
+			if (response.ok) {
+				const data = await response.json();
+				trades = data.trades || [];
+			}
+		} catch (e) {
+			console.error('Failed to load recent trades:', e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		if (coinSymbol) {
+			loading = true;
+			trades = [];
+			fetchTrades();
+		}
+	});
+</script>
+
+<Card.Root>
+	<Card.Header>
+		<Card.Title class="flex items-center gap-2">
+			<HugeiconsIcon icon={Activity01Icon} class="h-4 w-4" />
+			Recent Trades
+		</Card.Title>
+	</Card.Header>
+	<Card.Content class="relative">
+		{#if loading}
+			<div class="space-y-2">
+				{#each Array(3) as _}
+					<div class="bg-muted/60 h-10 animate-pulse rounded-lg"></div>
+				{/each}
+			</div>
+		{:else if trades.length === 0}
+			<div class="py-4 text-center">
+				<HugeiconsIcon icon={Activity01Icon} class="text-muted-foreground mx-auto mb-2 h-8 w-8" />
+				<p class="text-muted-foreground text-sm">No trades yet</p>
+			</div>
+		{:else}
+			<div class="space-y-2">
+				{#each trades as trade (trade.timestamp)}
+					<div class="hover:bg-muted/50 flex items-center justify-between gap-2 rounded-lg border p-2.5 transition-colors">
+						<div class="flex min-w-0 items-center gap-2">
+							<button
+								class="flex min-w-0 cursor-pointer items-center gap-1.5 rounded-sm underline-offset-4 hover:underline"
+								onclick={() => goto(`/user/${trade.username}`)}
+							>
+								<Avatar.Root class="h-5 w-5 flex-shrink-0">
+									<Avatar.Image
+										src={getPublicUrl(trade.userImage ?? null)}
+										alt={trade.username}
+									/>
+									<Avatar.Fallback class="text-[10px]">
+										{trade.username.charAt(0).toUpperCase()}
+									</Avatar.Fallback>
+								</Avatar.Root>
+								<span class="max-w-[90px] truncate text-xs font-medium">@{trade.username}</span>
+							</button>
+						</div>
+						<div class="flex flex-shrink-0 items-center gap-1.5 font-mono text-xs">
+							{#if trade.type === 'BUY'}
+								<HugeiconsIcon icon={TradeUpIcon} class="h-3.5 w-3.5 text-green-500" />
+								<span class="text-green-500">BUY</span>
+							{:else}
+								<HugeiconsIcon icon={TradeDownIcon} class="h-3.5 w-3.5 text-red-500" />
+								<span class="text-red-500">SELL</span>
+							{/if}
+							<span>{formatValue(trade.totalValue)}</span>
+						</div>
+						<div class="text-muted-foreground flex flex-shrink-0 items-center gap-1 text-[10px]">
+							<HugeiconsIcon icon={Clock01Icon} class="h-3 w-3" />
+							<span class="whitespace-nowrap font-mono">{formatRelativeTime(new Date(trade.timestamp))}</span>
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</Card.Content>
+</Card.Root>

--- a/website/src/lib/components/self/TradeModal.svelte
+++ b/website/src/lib/components/self/TradeModal.svelte
@@ -27,7 +27,8 @@
 
 	let amount = $state('');
 	let loading = $state(false);
-	let sellByDollar = $state(false);
+	// true = amount is entered in tokens (coin), false = amount is entered in dollars
+	let tokenMode = $state(false);
 
 	let numericAmount = $derived(parseFloat(amount) || 0);
 	let currentPrice = $derived(coin.currentPrice || 0);
@@ -39,7 +40,7 @@
 	);
 
 	let effectiveSellCoinAmount = $derived(() => {
-		if (type !== 'SELL' || !sellByDollar || numericAmount <= 0) return numericAmount;
+		if (type !== 'SELL' || !tokenMode || numericAmount <= 0) return numericAmount;
 		const poolCoin = Number(coin.poolCoinAmount);
 		const poolBase = Number(coin.poolBaseCurrencyAmount);
 		if (poolCoin <= 0 || poolBase <= 0) return 0;
@@ -55,16 +56,33 @@
 		return Math.max(0, requiredCoins);
 	});
 
+	// Inverse of the AMM buy math: how many dollars it costs to buy `numericAmount` tokens.
+	let effectiveBuyCost = $derived(() => {
+		if (type !== 'BUY' || !tokenMode || numericAmount <= 0) return numericAmount;
+		const poolCoin = Number(coin.poolCoinAmount);
+		const poolBase = Number(coin.poolBaseCurrencyAmount);
+		if (poolCoin <= 0 || poolBase <= 0) return 0;
+		const k = poolCoin * poolBase;
+		const newPoolCoin = poolCoin - numericAmount;
+		if (newPoolCoin <= 0) return 0; // can't buy more tokens than exist in the pool
+		const newPoolBase = k / newPoolCoin;
+		const netIntoPool = newPoolBase - poolBase;
+		const spend = netIntoPool / (1 - SWAP_FEE_RATE);
+		return Math.max(0, spend);
+	});
+
 	let estimatedResult = $derived(
-		sellByDollar && type === 'SELL'
+		tokenMode && type === 'SELL'
 			? calculateEstimate(effectiveSellCoinAmount(), type, currentPrice)
-			: calculateEstimate(numericAmount, type, currentPrice)
+			: tokenMode && type === 'BUY'
+				? calculateEstimate(effectiveBuyCost(), type, currentPrice)
+				: calculateEstimate(numericAmount, type, currentPrice)
 	);
 	let hasValidAmount = $derived(numericAmount > 0);
 	let userBalance = $derived($PORTFOLIO_SUMMARY ? $PORTFOLIO_SUMMARY.baseCurrencyBalance : 0);
 	let hasEnoughFunds = $derived(() => {
-		if (type === 'BUY') return numericAmount <= userBalance;
-		if (sellByDollar) {
+		if (type === 'BUY') return tokenMode ? effectiveBuyCost() <= userBalance : numericAmount <= userBalance;
+		if (tokenMode) {
 			return effectiveSellCoinAmount() <= userHolding;
 		}
 		return numericAmount <= userHolding;
@@ -101,7 +119,7 @@
 		open = false;
 		amount = '';
 		loading = false;
-		sellByDollar = false;
+		tokenMode = false;
 	}
 
 	async function handleTrade() {
@@ -109,9 +127,11 @@
 
 		loading = true;
 		try {
-			const tradeAmount = (type === 'SELL' && sellByDollar)
+			const tradeAmount = (type === 'SELL' && tokenMode)
 				? effectiveSellCoinAmount()
-				: numericAmount;
+				: (type === 'BUY' && tokenMode)
+					? effectiveBuyCost()
+					: numericAmount;
 
 			const response = await fetch(`/api/coin/${coin.symbol}/trade`, {
 				method: 'POST',
@@ -152,11 +172,22 @@
 
 	function setMaxAmount() {
 		if (type === 'SELL') {
-			if (sellByDollar) {
+			if (tokenMode) {
+				amount = maxSellableAmount.toString();
+			} else {
 				const est = calculateEstimate(maxSellableAmount, 'SELL', currentPrice);
 				amount = (Math.floor(est.result * 100) / 100).toFixed(2);
-			} else {
-				amount = maxSellableAmount.toString();
+			}
+		} else if (type === 'BUY' && tokenMode) {
+			// Max tokens affordable with the full balance (inverse of the buy math)
+			const poolCoin = Number(coin.poolCoinAmount);
+			const poolBase = Number(coin.poolBaseCurrencyAmount);
+			if (poolCoin > 0 && poolBase > 0) {
+				const k = poolCoin * poolBase;
+				const netIntoPool = userBalance * (1 - SWAP_FEE_RATE);
+				const newPoolBase = poolBase + netIntoPool;
+				const newPoolCoin = k / newPoolBase;
+				amount = Math.max(0, poolCoin - newPoolCoin).toString();
 			}
 		} else if ($PORTFOLIO_SUMMARY) {
 			amount = userBalance.toString();
@@ -185,25 +216,29 @@
 			<!-- Amount Input -->
 			<div class="space-y-2">
 				<Label for="amount">
-					{type === 'BUY' ? 'Amount to spend ($)' : (sellByDollar ? 'Dollar amount to receive ($)' : `Amount (${coin.symbol})`)}
+					{type === 'BUY' ? (tokenMode ? `Amount (${coin.symbol})` : 'Amount to spend ($)') : (tokenMode ? `Amount (${coin.symbol})` : 'Dollar amount to receive ($)')}
 				</Label>
 				<div class="flex gap-2">
 					<Input
 						id="amount"
 						type="number"
-						step={type === 'BUY' || sellByDollar ? '0.01' : '1'}
+						step={tokenMode ? '1' : '0.01'}
 						min="0"
 						bind:value={amount}
 						placeholder="0.00"
 						class="flex-1"
 					/>
-					{#if type === 'SELL'}
-						<Button variant="outline" size="icon" class="h-9 w-9 shrink-0" onclick={() => { haptic.trigger('selection'); sellByDollar = !sellByDollar; amount = ''; }}>
-							{#key sellByDollar}
-								<HugeiconsIcon icon={sellByDollar ? Dollar02Icon : Coins01Icon} class="h-4 w-4" />
-							{/key}
-						</Button>
-					{/if}
+					<Button
+						variant="outline"
+						size="icon"
+						class="h-9 w-9 shrink-0"
+						title={tokenMode ? 'Enter amount in dollars' : `Enter amount in ${coin.symbol}`}
+						onclick={() => { haptic.trigger('selection'); tokenMode = !tokenMode; amount = ''; }}
+					>
+						{#key tokenMode}
+							<HugeiconsIcon icon={tokenMode ? Coins01Icon : Dollar02Icon} class="h-4 w-4" />
+						{/key}
+					</Button>
 					<Button variant="outline" size="sm" class="h-9 shrink-0" onclick={setMaxAmount}>Max</Button>
 				</div>
 				{#if type === 'SELL'}
@@ -226,12 +261,12 @@
 				<div class="bg-muted/50 rounded-lg p-3">
 					<div class="flex items-center justify-between">
 						<span class="text-sm font-medium">
-							{type === 'BUY' ? `${coin.symbol} you'll get:` : (sellByDollar ? `${coin.symbol} to sell:` : "You'll receive:")}
+							{type === 'BUY' ? `${coin.symbol} you'll get:` : (tokenMode ? `${coin.symbol} to sell:` : "You'll receive:")}
 						</span>
 						<span class="font-bold">
 							{#if type === 'BUY'}
 								~{estimatedResult.result.toFixed(6)} {coin.symbol}
-							{:else if sellByDollar}
+							{:else if tokenMode}
 								~{effectiveSellCoinAmount().toFixed(6)} {coin.symbol}
 							{:else}
 								~${estimatedResult.result.toFixed(6)}

--- a/website/src/lib/components/self/games/Wheel.svelte
+++ b/website/src/lib/components/self/games/Wheel.svelte
@@ -1,0 +1,337 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import {
+		Card,
+		CardContent,
+		CardDescription,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card';
+	import confetti from 'canvas-confetti';
+	import { toast } from 'svelte-sonner';
+	import { formatValue, playSound, showConfetti, showSchoolPrideCannons } from '$lib/utils';
+	import { volumeSettings } from '$lib/stores/volume-settings';
+	import { onMount } from 'svelte';
+	import { fetchPortfolioSummary } from '$lib/stores/portfolio-data';
+	import { haptic } from '$lib/stores/haptics';
+
+	import { WHEEL_SEGMENTS } from '$lib/data/wheel';
+
+	const SEGMENT_COUNT = WHEEL_SEGMENTS.length;
+	const SEGMENT_DEG = 360 / SEGMENT_COUNT;
+	const MAX_BET_AMOUNT = 1000000;
+	const WHEEL_RADIUS = 100;
+
+	const segmentColors = ['#ef4444', '#3b82f6', '#22c55e', '#eab308', '#a855f7', '#f97316'];
+
+	const wheelGradient = `conic-gradient(${WHEEL_SEGMENTS.map((multiplier, i) => {
+		const color = multiplier === 0 ? '#334155' : segmentColors[i % segmentColors.length];
+		return `${color} ${i * SEGMENT_DEG}deg ${(i + 1) * SEGMENT_DEG}deg`;
+	}).join(', ')})`;
+
+	interface WheelResult {
+		segmentIndex: number;
+		multiplier: number;
+		won: boolean;
+		payout: number;
+		newBalance: number;
+		amountWagered: number;
+	}
+
+	let {
+		balance = $bindable(),
+		onBalanceUpdate
+	}: {
+		balance: number;
+		onBalanceUpdate?: (newBalance: number) => void;
+	} = $props();
+
+	let betAmount = $state(10);
+	let betAmountDisplay = $state('10');
+	let isSpinning = $state(false);
+	let lastResult = $state<WheelResult | null>(null);
+	let rotation = $state(0);
+	let wheelElement: HTMLElement | null = null;
+
+	let canBet = $derived(
+		betAmount > 0 && betAmount <= balance && betAmount <= MAX_BET_AMOUNT && !isSpinning
+	);
+
+	function setBetAmount(amount: number) {
+		const clampedAmount = Math.min(amount, Math.min(balance, MAX_BET_AMOUNT));
+		if (clampedAmount >= 0) {
+			betAmount = clampedAmount;
+			betAmountDisplay = clampedAmount.toLocaleString();
+		}
+	}
+
+	function handleBetAmountInput(event: Event) {
+		const target = event.target as HTMLInputElement;
+		const value = target.value.replace(/,/g, '');
+		const numValue = parseFloat(value) || 0;
+		const clampedValue = Math.min(numValue, Math.min(balance, MAX_BET_AMOUNT));
+
+		betAmount = clampedValue;
+		betAmountDisplay = target.value;
+	}
+
+	function handleBetAmountBlur() {
+		betAmountDisplay = betAmount.toLocaleString();
+	}
+
+	function spinTo(index: number) {
+		// Segment i's center sits at i*30+15 degrees clockwise from the top.
+		// The pointer is fixed at the top, so the wheel must end rotated so that
+		// segment center lines up with it: rotation mod 360 == 360 - center.
+		const segmentCenter = index * SEGMENT_DEG + SEGMENT_DEG / 2;
+		const currentMod = ((rotation % 360) + 360) % 360;
+		const targetMod = (360 - segmentCenter + 360) % 360;
+		let delta = (targetMod - currentMod + 360) % 360;
+		const spins = 6;
+		rotation = rotation + spins * 360 + delta;
+
+		if (wheelElement) {
+			wheelElement.style.transform = `rotate(${rotation}deg)`;
+		}
+	}
+
+	async function spin() {
+		if (!canBet) return;
+
+		isSpinning = true;
+		lastResult = null;
+
+		try {
+			const response = await fetch('/api/arcade/wheel', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({
+					amount: betAmount
+				})
+			});
+
+			if (!response.ok) {
+				const errorData = await response.json();
+				throw new Error(errorData.error || 'Failed to place bet');
+			}
+
+			const resultData: WheelResult = await response.json();
+
+			playSound('dice');
+			if (wheelElement) {
+				wheelElement.style.transition = 'none';
+				wheelElement.style.transform = `rotate(${rotation}deg)`;
+				void wheelElement.offsetHeight;
+				wheelElement.style.transition = 'transform 4s cubic-bezier(0.1, 0.9, 0.1, 1)';
+				spinTo(resultData.segmentIndex);
+			}
+
+			await new Promise(resolve => setTimeout(resolve, 4200));
+
+			balance = resultData.newBalance;
+			lastResult = resultData;
+			onBalanceUpdate?.(resultData.newBalance);
+
+			if (resultData.won) {
+				haptic.trigger('success');
+				showConfetti(confetti);
+				showSchoolPrideCannons(confetti);
+			} else {
+				haptic.trigger('error');
+				playSound('lose');
+			}
+		} catch (error) {
+			console.error('Wheel spin error:', error);
+			haptic.trigger('error');
+			toast.error('Spin failed', {
+				description: error instanceof Error ? error.message : 'Unknown error occurred'
+			});
+		} finally {
+			isSpinning = false;
+		}
+	}
+
+	onMount(async () => {
+		volumeSettings.load();
+
+		try {
+			const data = await fetchPortfolioSummary();
+			if (data) {
+				balance = data.baseCurrencyBalance;
+				onBalanceUpdate?.(data.baseCurrencyBalance);
+			}
+		} catch (error) {
+			console.error('Failed to fetch balance:', error);
+		}
+	});
+</script>
+
+<Card>
+	<CardHeader>
+		<CardTitle>Wheel of Fortune</CardTitle>
+		<CardDescription>
+			Spin the wheel and land on a multiplier. Watch out for the zero segments!
+		</CardDescription>
+	</CardHeader>
+	<CardContent>
+		<div class="grid grid-cols-1 gap-8 md:grid-cols-2">
+			<div class="flex flex-col space-y-4">
+				<div class="text-center">
+					<p class="text-muted-foreground text-sm">Balance</p>
+					<p class="text-2xl font-bold">{formatValue(balance)}</p>
+				</div>
+
+				<!-- Wheel -->
+				<div class="relative mx-auto flex h-64 w-64 items-center justify-center">
+					<!-- Pointer (fixed at top) -->
+					<div class="pointer-events-none absolute left-1/2 top-0 z-10 -translate-x-1/2 -translate-y-1/2">
+						<div class="border-x-[10px] border-t-[18px] border-x-transparent border-t-white drop-shadow"></div>
+					</div>
+
+					<div class="wheel" bind:this={wheelElement} style="background: {wheelGradient}">
+						{#each WHEEL_SEGMENTS as multiplier, i}
+							<span
+								class="wheel-label"
+								style="--angle: {i * SEGMENT_DEG + SEGMENT_DEG / 2}deg; --radius: {WHEEL_RADIUS}px"
+							>
+								{multiplier === 0 ? '0' : `${multiplier}x`}
+							</span>
+						{/each}
+						<div class="wheel-hub"></div>
+					</div>
+				</div>
+
+				<div class="flex items-center justify-center text-center">
+					{#if lastResult && !isSpinning}
+						<div class="bg-muted/50 w-full rounded-lg p-3">
+							{#if lastResult.won}
+								<p class="text-success font-semibold">WIN {lastResult.multiplier}x</p>
+								<p class="text-sm">
+									Won {formatValue(lastResult.payout)} on {lastResult.multiplier}x
+								</p>
+							{:else}
+								<p class="text-destructive font-semibold">LOSS</p>
+								<p class="text-sm">
+									Lost {formatValue(lastResult.amountWagered)} on {lastResult.multiplier}x
+								</p>
+							{/if}
+						</div>
+					{/if}
+				</div>
+			</div>
+
+			<div class="space-y-4">
+				<div>
+					<label for="bet-amount" class="mb-2 block text-sm font-medium">Bet Amount</label>
+					<Input
+						id="bet-amount"
+						type="text"
+						value={betAmountDisplay}
+						oninput={handleBetAmountInput}
+						onblur={handleBetAmountBlur}
+						disabled={isSpinning}
+						placeholder="Enter bet amount"
+					/>
+					<p class="text-muted-foreground mt-1 text-xs">
+						Max bet: {MAX_BET_AMOUNT.toLocaleString()}
+					</p>
+				</div>
+
+				<div>
+					<div class="grid grid-cols-4 gap-2">
+						<Button
+							size="sm"
+							variant="outline"
+							onclick={() => setBetAmount(Math.floor(Math.min(balance || 0, MAX_BET_AMOUNT) * 0.25))}
+							disabled={isSpinning}>25%</Button
+						>
+						<Button
+							size="sm"
+							variant="outline"
+							onclick={() => setBetAmount(Math.floor(Math.min(balance || 0, MAX_BET_AMOUNT) * 0.5))}
+							disabled={isSpinning}>50%</Button
+						>
+						<Button
+							size="sm"
+							variant="outline"
+							onclick={() => setBetAmount(Math.floor(Math.min(balance || 0, MAX_BET_AMOUNT) * 0.75))}
+							disabled={isSpinning}>75%</Button
+						>
+						<Button
+							size="sm"
+							variant="outline"
+							onclick={() => setBetAmount(Math.floor(Math.min(balance || 0, MAX_BET_AMOUNT)))}
+							disabled={isSpinning}>Max</Button
+						>
+					</div>
+				</div>
+
+				<Button class="h-12 w-full text-lg" onclick={spin} disabled={!canBet}>
+					{isSpinning ? 'Spinning...' : 'Spin'}
+				</Button>
+
+				<div class="bg-muted/50 space-y-1.5 rounded-lg p-3 text-xs">
+					<p class="text-muted-foreground mb-2 font-medium">Payouts</p>
+					<div class="flex flex-wrap gap-1.5">
+						{#each WHEEL_SEGMENTS as multiplier, i}
+							<span
+								class="rounded px-1.5 py-0.5 font-mono font-medium"
+								class:text-green-500={multiplier > 1}
+								class:text-yellow-500={multiplier === 1}
+								class:text-destructive={multiplier === 0}
+								class:text-muted-foreground={multiplier > 0 && multiplier < 1}
+							>
+								{multiplier === 0 ? '0' : `${multiplier}x`}
+							</span>
+						{/each}
+					</div>
+					<p class="text-muted-foreground mt-2">
+						Land on a multiplier to win your bet times that amount. Zero segments lose your bet.
+					</p>
+				</div>
+			</div>
+		</div>
+	</CardContent>
+</Card>
+
+<style>
+	.wheel {
+		position: relative;
+		width: 260px;
+		height: 260px;
+		border-radius: 50%;
+		border: 4px solid var(--border);
+		box-shadow: 0 4px 24px rgba(0, 0, 0, 0.35);
+		transition: transform 4s cubic-bezier(0.1, 0.9, 0.1, 1);
+	}
+
+	.wheel-label {
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%) rotate(var(--angle)) translateY(calc(-1 * var(--radius))) rotate(calc(-1 * var(--angle)));
+		color: #fff;
+		font-size: 0.95rem;
+		font-weight: 700;
+		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+		text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+		user-select: none;
+		pointer-events: none;
+	}
+
+	.wheel-hub {
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		width: 36px;
+		height: 36px;
+		border-radius: 50%;
+		background: var(--card);
+		border: 3px solid var(--border);
+		transform: translate(-50%, -50%);
+		z-index: 2;
+	}
+</style>

--- a/website/src/lib/data/wheel.ts
+++ b/website/src/lib/data/wheel.ts
@@ -1,0 +1,5 @@
+// Shared config for the Wheel of Fortune arcade game.
+// Used by the server (/api/arcade/wheel) to resolve outcomes and by the
+// client (Wheel.svelte) to draw the wheel. Multipliers sum to 11.5 across 12
+// segments for a ~4.2% house edge (95.8% RTP).
+export const WHEEL_SEGMENTS = [0, 1.5, 0, 2, 0, 2.5, 0, 0.5, 0, 4, 0, 1];

--- a/website/src/lib/server/api-auth.ts
+++ b/website/src/lib/server/api-auth.ts
@@ -1,5 +1,34 @@
 import { auth } from "$lib/auth";
 import { error } from "@sveltejs/kit";
+import { redis } from "$lib/server/redis";
+
+export const MAX_DAILY_API_REQUESTS = 2000;
+
+function getUsageKey(userId: string): string {
+    const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD in UTC
+    return `api:usage:${userId}:${today}`;
+}
+
+function secondsUntilEndOfDayUTC(): number {
+    const now = new Date();
+    const endOfDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
+    return Math.max(60, Math.ceil((endOfDay.getTime() - now.getTime()) / 1000));
+}
+
+/**
+ * Reads how many API requests the user has used today. Used by the API
+ * dashboard so the displayed usage matches the enforced limit and always
+ * resets daily. Returns 0 when there is no counter (or Redis is unavailable).
+ */
+export async function getDailyApiUsage(userId: string): Promise<number> {
+    try {
+        const value = await redis.get(getUsageKey(userId));
+        return Number(value || 0);
+    } catch (e) {
+        console.error('Failed to read API usage from Redis:', e);
+        return 0;
+    }
+}
 
 export async function verifyApiKeyAndGetUser(request: Request) {
     const authHeader = request.headers.get('Authorization');
@@ -16,5 +45,28 @@ export async function verifyApiKeyAndGetUser(request: Request) {
         throw error(401, 'Invalid API key');
     }
 
-    return key.userId;
+    const userId = key.userId;
+
+    // Enforce the daily request limit with an atomic Redis counter that expires
+    // at the end of the day. This replaces the old `remaining` field on the key,
+    // which was never decremented consistently and never reset, letting users
+    // use effectively unlimited requests while the dashboard stayed frozen.
+    try {
+        const usage = await redis.incr(getUsageKey(userId));
+        if (usage === 1) {
+            await redis.expire(getUsageKey(userId), secondsUntilEndOfDayUTC()).catch(() => {});
+        }
+        if (usage > MAX_DAILY_API_REQUESTS) {
+            throw error(429, 'Daily API limit exceeded. Limit resets at midnight UTC.');
+        }
+    } catch (e) {
+        if (e && typeof e === 'object' && 'status' in e && (e as any).status === 429) {
+            throw e;
+        }
+        // Fail open if Redis is unavailable so a Redis blip doesn't take down
+        // the entire public API.
+        console.error('Failed to enforce API usage limit:', e);
+    }
+
+    return userId;
 }

--- a/website/src/routes/api/+page.server.ts
+++ b/website/src/routes/api/+page.server.ts
@@ -1,4 +1,5 @@
 import { auth } from '$lib/auth';
+import { getDailyApiUsage } from '$lib/server/api-auth';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async (event) => {
@@ -11,7 +12,7 @@ export const load: PageServerLoad = async (event) => {
     const keys = await auth.api.listApiKeys({ headers: event.request.headers });
     const key = keys.length > 0 ? keys[0] : null;
 
-    const todayUsage = key ? 2000 - (key.remaining || 0) : 0;
+    const todayUsage = key ? await getDailyApiUsage(key.userId) : 0;
 
     return {
         apiKey: key,

--- a/website/src/routes/api/arcade/wheel/+server.ts
+++ b/website/src/routes/api/arcade/wheel/+server.ts
@@ -1,0 +1,117 @@
+import { auth } from '$lib/auth';
+import { error, json } from '@sveltejs/kit';
+import { db } from '$lib/server/db';
+import { user } from '$lib/server/db/schema';
+import { eq } from 'drizzle-orm';
+import { randomInt } from 'crypto';
+import { publishArcadeActivity } from '$lib/server/arcade-activity';
+import { checkAndAwardAchievements } from '$lib/server/achievements';
+import { validateBetAmount } from '$lib/utils';
+import { WHEEL_SEGMENTS } from '$lib/data/wheel';
+import type { RequestHandler } from './$types';
+
+interface WheelRequest {
+	amount: number;
+}
+
+export const POST: RequestHandler = async ({ request }) => {
+	const session = await auth.api.getSession({
+		headers: request.headers
+	});
+
+	if (!session?.user) {
+		throw error(401, 'Not authenticated');
+	}
+
+	try {
+		const { amount }: WheelRequest = await request.json();
+		const roundedBet = validateBetAmount(amount);
+
+		const userId = Number(session.user.id);
+
+		const result = await db.transaction(async (tx) => {
+			const [userData] = await tx
+				.select({
+					baseCurrencyBalance: user.baseCurrencyBalance,
+					arcadeLosses: user.arcadeLosses,
+					arcadeWins: user.arcadeWins,
+					totalArcadeGamesPlayed: user.totalArcadeGamesPlayed,
+					arcadeWinStreak: user.arcadeWinStreak,
+					arcadeBestWinStreak: user.arcadeBestWinStreak,
+					totalArcadeWagered: user.totalArcadeWagered
+				})
+				.from(user)
+				.where(eq(user.id, userId))
+				.for('update')
+				.limit(1);
+
+			const currentBalance = Number(userData.baseCurrencyBalance);
+			const roundedBalance = Math.round(currentBalance * 100000000) / 100000000;
+
+			if (roundedBet > roundedBalance) {
+				throw new Error(
+					`Insufficient funds. You need $${roundedBet.toFixed(2)} but only have $${roundedBalance.toFixed(2)}`
+				);
+			}
+
+			// Server-side result, never trusted from the client.
+			const segmentIndex = randomInt(0, WHEEL_SEGMENTS.length);
+			const multiplier = WHEEL_SEGMENTS[segmentIndex];
+
+			const payout = roundedBet * multiplier;
+			const newBalance = roundedBalance - roundedBet + payout;
+
+			const netResult = payout - roundedBet;
+			const isWin = netResult > 0;
+
+			const updateData: any = {
+				baseCurrencyBalance: newBalance.toFixed(8),
+				updatedAt: new Date()
+			};
+
+			if (isWin) {
+				updateData.arcadeWins = `${Number(userData.arcadeWins || 0) + netResult}`;
+				const newWinStreak = (userData.arcadeWinStreak || 0) + 1;
+				updateData.arcadeWinStreak = newWinStreak;
+				updateData.arcadeBestWinStreak = Math.max(newWinStreak, userData.arcadeBestWinStreak || 0);
+			} else {
+				updateData.arcadeLosses = `${Number(userData.arcadeLosses || 0) + Math.abs(netResult)}`;
+				updateData.arcadeWinStreak = 0;
+			}
+			updateData.totalArcadeGamesPlayed = (userData.totalArcadeGamesPlayed || 0) + 1;
+			updateData.totalArcadeWagered = `${Number(userData.totalArcadeWagered || 0) + roundedBet}`;
+
+			await tx.update(user).set(updateData).where(eq(user.id, userId));
+
+			return {
+				segmentIndex,
+				multiplier,
+				won: isWin,
+				payout,
+				newBalance,
+				amountWagered: roundedBet
+			};
+		});
+
+		await publishArcadeActivity(
+			userId,
+			result.won ? result.payout : result.amountWagered,
+			result.won,
+			'wheel',
+			2000
+		);
+
+		await checkAndAwardAchievements(userId, ['arcade', 'wealth'], {
+			arcadeWon: result.won,
+			arcadeWager: result.amountWagered
+		});
+
+		return json(result);
+	} catch (e) {
+		console.error('Wheel API error:', e);
+		if (e instanceof Error && e.message.startsWith('Insufficient funds')) {
+			return json({ error: e.message }, { status: 400 });
+		}
+		return json({ error: 'Internal server error' }, { status: 500 });
+	}
+};

--- a/website/src/routes/api/keys/+server.ts
+++ b/website/src/routes/api/keys/+server.ts
@@ -35,14 +35,14 @@ export const POST: RequestHandler = async (event) => {
         throw error(400, 'You can only have one API key at a time');
     }
 
+    // Note: `remaining` and `permissions` can only be set from the server auth
+    // instance (better-auth rejects them on authenticated requests), and a
+    // non-refilling `remaining` count would exhaust the key forever. The daily
+    // 2000-request limit is enforced separately by `verifyApiKeyAndGetUser`
+    // with a Redis counter that resets every day.
     const apiKey = await auth.api.createApiKey({
         body: {
-            name: "API Key",
-            remaining: 2000,
-            permissions: {
-                api: ['read']
-            },
-            userId: session.user.id
+            name: "API Key"
         },
         headers: event.request.headers
     });

--- a/website/src/routes/api/keys/[id]/regenerate/+server.ts
+++ b/website/src/routes/api/keys/[id]/regenerate/+server.ts
@@ -24,39 +24,23 @@ export const POST: RequestHandler = async (event) => {
         throw error(403, 'Not authorized to regenerate this API key');
     }
 
-    console.log(existingKey.remaining)
     await auth.api.deleteApiKey({
         body: { keyId: event.params.id },
         headers: event.request.headers
     });
 
-    let parsedPermissions: Record<string, string[]> | undefined = existingKey.permissions as Record<string, string[]> | undefined;
-    if (typeof existingKey.permissions === 'string') {
-        try {
-            const parsed = JSON.parse(existingKey.permissions);
-            parsedPermissions = parsed && typeof parsed === 'object' ? parsed : undefined;
-        } catch {
-            parsedPermissions = undefined;
-        }
-    }
-
+    // Same as create: `remaining`, `permissions`, and rate-limit fields can only
+    // be set from the server auth instance, and a non-refilling `remaining`
+    // would exhaust the key forever. The daily limit is enforced separately in
+    // `verifyApiKeyAndGetUser`, and default permissions come from the plugin
+    // config.
     const newKey = await auth.api.createApiKey({
         body: {
             name: existingKey.name ?? undefined,
-            userId: existingKey.userId,
-            remaining: existingKey.remaining,
-            refillAmount: existingKey.refillAmount ?? undefined,
-            refillInterval: existingKey.refillInterval ?? undefined,
-            rateLimitEnabled: existingKey.rateLimitEnabled,
-            rateLimitTimeWindow: existingKey.rateLimitTimeWindow ?? undefined,
-            rateLimitMax: existingKey.rateLimitMax ?? undefined,
-            permissions: parsedPermissions,
             metadata: existingKey.metadata
         },
         headers: event.request.headers
     });
-    console.log(existingKey.remaining)
-    console.log(newKey.remaining)
 
     return json(newKey);
 };

--- a/website/src/routes/api/trades/recent/+server.ts
+++ b/website/src/routes/api/trades/recent/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import { db } from '$lib/server/db';
 import { transaction, user, coin } from '$lib/server/db/schema';
-import { desc, gte, eq } from 'drizzle-orm';
+import { desc, gte, eq, and } from 'drizzle-orm';
 import { validateSearchParams } from '$lib/utils/validation';
 
 export async function GET({ url }) {
@@ -9,6 +9,7 @@ export async function GET({ url }) {
     const requestedLimit = params.getPositiveInt('limit', 100);
     const limit = Math.min(requestedLimit, 1000);
     const minValue = params.getNonNegativeFloat('minValue', 0);
+    const coinSymbol = params.getString('coin', '').toUpperCase();
 
     try {
         const trades = await db
@@ -29,9 +30,12 @@ export async function GET({ url }) {
             .innerJoin(user, eq(user.id, transaction.userId))
             .innerJoin(coin, eq(coin.id, transaction.coinId))
             .where(
-                minValue > 0
-                    ? gte(transaction.totalBaseCurrencyAmount, minValue.toString())
-                    : undefined
+                and(
+                    minValue > 0
+                        ? gte(transaction.totalBaseCurrencyAmount, minValue.toString())
+                        : undefined,
+                    coinSymbol ? eq(coin.symbol, coinSymbol) : undefined
+                )
             )
             .orderBy(desc(transaction.timestamp))
             .limit(limit);

--- a/website/src/routes/arcade/+page.svelte
+++ b/website/src/routes/arcade/+page.svelte
@@ -9,6 +9,7 @@
 	import SEO from '$lib/components/self/SEO.svelte';
 	import Dice from '$lib/components/self/games/Dice.svelte';
 	import Tower from '$lib/components/self/games/Tower.svelte';
+	import Wheel from '$lib/components/self/games/Wheel.svelte';
 	import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '$lib/components/ui/card';
 	import { arcadeActivityStore } from '$lib/stores/websocket';
 	import * as Avatar from '$lib/components/ui/avatar';
@@ -52,8 +53,8 @@
 
 <SEO 
 	title="Arcade - Rugplay"
-	description="Play virtual arcade games with simulated currency in Rugplay. Try coinflip, slots, and mines games using virtual money with no real-world value - purely for entertainment."
-	keywords="virtual arcade simulation, coinflip game, slots game, mines game, virtual arcade, simulated games, entertainment games"
+	description="Play virtual arcade games with simulated currency in Rugplay. Try coinflip, slots, mines, dice, tower, and wheel games using virtual money with no real-world value - purely for entertainment."
+	keywords="virtual arcade simulation, coinflip game, slots game, mines game, wheel of fortune, virtual arcade, simulated games, entertainment games"
 />
 
 <SignInConfirmDialog bind:open={shouldSignIn} />
@@ -103,6 +104,12 @@
 				>
 					Tower
 				</Button>
+				<Button
+					variant={activeGame === 'wheel' ? 'default' : 'outline'}
+					onclick={() => (activeGame = 'wheel')}
+				>
+					Wheel
+				</Button>
 			</div>
 
 			<!-- Game Content -->
@@ -116,6 +123,8 @@
 				<Dice bind:balance onBalanceUpdate={handleBalanceUpdate} />
 			{:else if activeGame === 'tower'}
 				<Tower bind:balance onBalanceUpdate={handleBalanceUpdate} />
+			{:else if activeGame === 'wheel'}
+				<Wheel bind:balance onBalanceUpdate={handleBalanceUpdate} />
 			{/if}
 
 			<!-- Live Arcade Activity Feed -->

--- a/website/src/routes/coin/[coinSymbol]/+page.svelte
+++ b/website/src/routes/coin/[coinSymbol]/+page.svelte
@@ -11,6 +11,7 @@
 	import UserName from '$lib/components/self/UserName.svelte';
 	import CoinSkeleton from '$lib/components/self/skeletons/CoinSkeleton.svelte';
 	import TopHolders from '$lib/components/self/TopHolders.svelte';
+	import CoinTrades from '$lib/components/self/CoinTrades.svelte';
 	import { HugeiconsIcon } from '@hugeicons/svelte';
 	import {
 		TradeUpIcon,
@@ -775,6 +776,8 @@
 					</Card.Root>
 					<!-- Top Holders -->
 					<TopHolders coinSymbol={coin.symbol} />
+					<!-- Recent Trades -->
+					<CoinTrades coinSymbol={coin.symbol} />
 				</div>
 			</div>
 


### PR DESCRIPTION
Round one of community-requested fixes and features, all verified running locally against Postgres + Redis.

## Bug fixes

**API credits now actually work (#194)**
- Real daily limit enforcement: an atomic Redis counter (`api:usage:{userId}:{date}`) that increments per request, returns 429 after 2000, and resets at midnight UTC.
- The API dashboard reads that same counter, so "requests remaining today" is accurate and resets daily instead of being frozen forever.
- **Also fixes API key creation**, which was completely broken on better-auth 1.2: `createApiKey` rejects `remaining` / `permissions` / `userId` in the body on authenticated requests (500 on every "Create API Key"). Keys now get their permissions from the plugin's `defaultPermissions`, and the daily limit is enforced by the Redis counter instead of the never-refilling `remaining` field (which also had the old bug of exhausting keys permanently).

## Features

**Buy by token amount (#195)** — the Buy modal now has the same token/dollar toggle as Sell. It computes the AMM cost in dollars for the entered token amount, shows the estimate and fee, and Max fills in the max affordable tokens.

**Recent trades on coin page (#173)** — new "Recent Trades" panel under Top Holders showing the last 10 buys/sells for that coin, backed by a `coin` filter added to `/api/trades/recent`.

**Wheel of Fortune arcade game (#158)** — the requested game nobody had claimed yet (Crash, Blackjack, Poker already have PRs). 12 segments (0x to 4x, ~4.2% house edge), server-side outcome, CSS spin animation that lands on the result, live activity feed + achievements integration.

## Verification
- `npm run build` passes.
- `svelte-check`: no errors in any changed file (8 pre-existing errors remain in untouched files).
- Manually tested locally: created an API key, hit `/api/v1/top` 5x, dashboard showed 6/2000 used; bought TEST by token amount; spun the Wheel and won.
